### PR TITLE
Enable zero-conf channel and specify receiving address

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build wasm
         env:
           RUSTUP_TOOLCHAIN: nightly-2023-10-24
-        run: wasm-pack build ./mutiny-wasm --release --weak-refs --target web --scope mutinywallet
+        run: wasm-pack build ./mutiny-wasm --release --weak-refs --target web --scope nervina-labs
 
       - name: Publish wasm
         run: wasm-pack publish --access public -t web

--- a/justfile
+++ b/justfile
@@ -1,17 +1,17 @@
 pack:
-    wasm-pack build ./mutiny-wasm --weak-refs --target web --scope mutinywallet
+    wasm-pack build ./mutiny-wasm --weak-refs --target web --scope nervina-labs
 
 link:
-    wasm-pack build ./mutiny-wasm --dev --weak-refs --target web --scope mutinywallet && cd mutiny-wasm/pkg && pnpm link --global
+    wasm-pack build ./mutiny-wasm --dev --weak-refs --target web --scope nervina-labs && cd mutiny-wasm/pkg && pnpm link --global
 
 login:
-    wasm-pack login --scope=@mutinywallet
+    wasm-pack login --scope=@nervina-labs
 
 dev: 
-    wasm-pack build ./mutiny-wasm --dev --weak-refs --target web --scope mutinywallet
+    wasm-pack build ./mutiny-wasm --dev --weak-refs --target web --scope nervina-labs
 
 release:
-    wasm-pack build ./mutiny-wasm --release --weak-refs --target web --scope mutinywallet
+    wasm-pack build ./mutiny-wasm --release --weak-refs --target web --scope nervina-labs
 
 publish:
     wasm-pack publish --access public -t web

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -406,30 +406,42 @@ impl<S: MutinyStorage> EventHandler<S> {
                     Err(e) => log_debug!(self.logger, "EVENT: OpenChannelRequest error: {e:?}"),
                 };
 
-                let lsp_pubkey = match self.lsp_client {
-                    Some(ref lsp) => Some(lsp.get_lsp_pubkey().await),
-                    None => None,
-                };
+                // TODO: Based on the matching result of the LSP pubkey, decide whether to open a 0-confirmation channel.
+                // let lsp_pubkey = match self.lsp_client {
+                //     Some(ref lsp) => Some(lsp.get_lsp_pubkey().await),
+                //     None => None,
+                // };
 
-                if lsp_pubkey.as_ref() != Some(&counterparty_node_id) {
-                    // did not match the lsp pubkey, normal open
-                    let result = self.channel_manager.accept_inbound_channel(
+                // accept 0 conf by default
+                let result = self
+                    .channel_manager
+                    .accept_inbound_channel_from_trusted_peer_0conf(
                         &temporary_channel_id,
                         &counterparty_node_id,
                         internal_channel_id,
                     );
-                    log_result(result);
-                } else {
-                    // matched lsp pubkey, accept 0 conf
-                    let result = self
-                        .channel_manager
-                        .accept_inbound_channel_from_trusted_peer_0conf(
-                            &temporary_channel_id,
-                            &counterparty_node_id,
-                            internal_channel_id,
-                        );
-                    log_result(result);
-                }
+                log_result(result);
+
+                // TODO: Based on the matching result of the LSP pubkey, decide whether to open a 0-confirmation channel.
+                // if lsp_pubkey.as_ref() != Some(&counterparty_node_id) {
+                //     // did not match the lsp pubkey, normal open
+                //     let result = self.channel_manager.accept_inbound_channel(
+                //         &temporary_channel_id,
+                //         &counterparty_node_id,
+                //         internal_channel_id,
+                //     );
+                //     log_result(result);
+                // } else {
+                // matched lsp pubkey, accept 0 conf
+                // let result = self
+                //     .channel_manager
+                //     .accept_inbound_channel_from_trusted_peer_0conf(
+                //         &temporary_channel_id,
+                //         &counterparty_node_id,
+                //         internal_channel_id,
+                //     );
+                // log_result(result);
+                // }
             }
             Event::PaymentPathSuccessful { .. } => {
                 log_debug!(self.logger, "EVENT: PaymentPathSuccessful, ignored");

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -147,6 +147,9 @@ pub enum MutinyJsError {
     /// Invalid Arguments were given
     #[error("Invalid Arguments were given")]
     InvalidArgumentsError,
+    /// Invalid BTC Address or Network was given
+    #[error("Invalid BTC Address or Network was given")]
+    InvalidAddressNetworkError,
     /// Incorrect password entered.
     #[error("Incorrect password entered.")]
     IncorrectPassword,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1044,9 +1044,9 @@ impl MutinyWallet {
         &self,
         outpoint: String,
         address: String,
-        network: Option<String>,
         force: bool,
         abandon: bool,
+        network: Option<String>,
     ) -> Result<(), MutinyJsError> {
         let outpoint: OutPoint =
             OutPoint::from_str(&outpoint).map_err(|_| MutinyJsError::InvalidArgumentsError)?;

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1038,7 +1038,7 @@ impl MutinyWallet {
     /// This should only be used if the channel will never actually be opened.
     ///
     /// If both force and abandon are true, an error will be returned.
-    /// The address must match the network and the network: "bitcoin", "testnet", "signet"t, "regtest"
+    /// The address must match the network and the network: "bitcoin", "testnet", "signet", "regtest"
     #[wasm_bindgen]
     pub async fn close_channel(
         &self,


### PR DESCRIPTION
## Changes

- Enable zero confirmation channel
- Specify the receiving address when the channel is closed
- Update wasm-pack scope to `nervina-labs`