### PR TITLE
Update mutiny node methods and parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.9.7"
+version = "1.9.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.7.13"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.9.1"
+version = "1.9.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -406,41 +406,38 @@ impl<S: MutinyStorage> EventHandler<S> {
                     Err(e) => log_debug!(self.logger, "EVENT: OpenChannelRequest error: {e:?}"),
                 };
 
-                // accept zero-confirmation channel by default
-                let result = self
-                    .channel_manager
-                    .accept_inbound_channel_from_trusted_peer_0conf(
+                let lsp_pubkey = match self.lsp_client {
+                    Some(ref lsp) => Some(lsp.get_lsp_pubkey().await),
+                    None => None,
+                };
+                log_debug!(
+                    self.logger,
+                    "EVENT: OpenChannelRequest Lsp pubkey: {lsp_pubkey:?}"
+                );
+
+                if lsp_pubkey.as_ref() != Some(&counterparty_node_id) {
+                    // did not match the lsp pubkey, normal open
+                    let result = self.channel_manager.accept_inbound_channel(
                         &temporary_channel_id,
                         &counterparty_node_id,
                         internal_channel_id,
                     );
-                log_result(result);
-
-                // TODO: Based on the matching result of the LSP pubkey, decide whether to open a zero-confirmation channel.
-                // let lsp_pubkey = match self.lsp_client {
-                //     Some(ref lsp) => Some(lsp.get_lsp_pubkey().await),
-                //     None => None,
-                // };
-
-                // if lsp_pubkey.as_ref() != Some(&counterparty_node_id) {
-                //     // did not match the lsp pubkey, normal open
-                //     let result = self.channel_manager.accept_inbound_channel(
-                //         &temporary_channel_id,
-                //         &counterparty_node_id,
-                //         internal_channel_id,
-                //     );
-                //     log_result(result);
-                // } else {
-                //     // matched lsp pubkey, accept 0 conf
-                //     let result = self
-                //         .channel_manager
-                //         .accept_inbound_channel_from_trusted_peer_0conf(
-                //             &temporary_channel_id,
-                //             &counterparty_node_id,
-                //             internal_channel_id,
-                //         );
-                //     log_result(result);
-                // }
+                    log_result(result);
+                } else {
+                    // matched lsp pubkey, accept 0 conf
+                    let result = self
+                        .channel_manager
+                        .accept_inbound_channel_from_trusted_peer_0conf(
+                            &temporary_channel_id,
+                            &counterparty_node_id,
+                            internal_channel_id,
+                        );
+                    log_result(result);
+                    log_debug!(
+                        self.logger,
+                        "Accept zero confirmation channel when matched LSP Pubkey"
+                    );
+                }
             }
             Event::PaymentPathSuccessful { .. } => {
                 log_debug!(self.logger, "EVENT: PaymentPathSuccessful, ignored");

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -406,30 +406,41 @@ impl<S: MutinyStorage> EventHandler<S> {
                     Err(e) => log_debug!(self.logger, "EVENT: OpenChannelRequest error: {e:?}"),
                 };
 
-                let lsp_pubkey = match self.lsp_client {
-                    Some(ref lsp) => Some(lsp.get_lsp_pubkey().await),
-                    None => None,
-                };
-
-                if lsp_pubkey.as_ref() != Some(&counterparty_node_id) {
-                    // did not match the lsp pubkey, normal open
-                    let result = self.channel_manager.accept_inbound_channel(
+                // accept zero-confirmation channel by default
+                let result = self
+                    .channel_manager
+                    .accept_inbound_channel_from_trusted_peer_0conf(
                         &temporary_channel_id,
                         &counterparty_node_id,
                         internal_channel_id,
                     );
-                    log_result(result);
-                } else {
-                    // matched lsp pubkey, accept 0 conf
-                    let result = self
-                        .channel_manager
-                        .accept_inbound_channel_from_trusted_peer_0conf(
-                            &temporary_channel_id,
-                            &counterparty_node_id,
-                            internal_channel_id,
-                        );
-                    log_result(result);
-                }
+                log_result(result);
+
+                // TODO: Based on the matching result of the LSP pubkey, decide whether to open a zero-confirmation channel.
+                // let lsp_pubkey = match self.lsp_client {
+                //     Some(ref lsp) => Some(lsp.get_lsp_pubkey().await),
+                //     None => None,
+                // };
+
+                // if lsp_pubkey.as_ref() != Some(&counterparty_node_id) {
+                //     // did not match the lsp pubkey, normal open
+                //     let result = self.channel_manager.accept_inbound_channel(
+                //         &temporary_channel_id,
+                //         &counterparty_node_id,
+                //         internal_channel_id,
+                //     );
+                //     log_result(result);
+                // } else {
+                //     // matched lsp pubkey, accept 0 conf
+                //     let result = self
+                //         .channel_manager
+                //         .accept_inbound_channel_from_trusted_peer_0conf(
+                //             &temporary_channel_id,
+                //             &counterparty_node_id,
+                //             internal_channel_id,
+                //         );
+                //     log_result(result);
+                // }
             }
             Event::PaymentPathSuccessful { .. } => {
                 log_debug!(self.logger, "EVENT: PaymentPathSuccessful, ignored");

--- a/mutiny-core/src/lsp/voltage.rs
+++ b/mutiny-core/src/lsp/voltage.rs
@@ -205,60 +205,61 @@ impl LspClient {
         Ok(())
     }
 
-    /// Verify that the invoice has all the parameters we expect
-    /// Returns an Option with an error message if the invoice is invalid
-    pub(crate) fn verify_invoice(
-        &self,
-        our_invoice: &Bolt11Invoice,
-        lsp_invoice: &Bolt11Invoice,
-        lsp_fee_msats: u64,
-    ) -> Option<String> {
-        if lsp_invoice.network() != our_invoice.network() {
-            return Some(format!(
-                "Received invoice on wrong network: {} != {}",
-                lsp_invoice.network(),
-                our_invoice.network()
-            ));
-        }
+    // TODO: Skip LSP invoice verifying
+    // Verify that the invoice has all the parameters we expect
+    // Returns an Option with an error message if the invoice is invalid
+    // pub(crate) fn verify_invoice(
+    //     &self,
+    //     our_invoice: &Bolt11Invoice,
+    //     lsp_invoice: &Bolt11Invoice,
+    //     lsp_fee_msats: u64,
+    // ) -> Option<String> {
+    //     if lsp_invoice.network() != our_invoice.network() {
+    //         return Some(format!(
+    //             "Received invoice on wrong network: {} != {}",
+    //             lsp_invoice.network(),
+    //             our_invoice.network()
+    //         ));
+    //     }
 
-        if lsp_invoice.payment_hash() != our_invoice.payment_hash() {
-            return Some(format!(
-                "Received invoice with wrong payment hash: {} != {}",
-                lsp_invoice.payment_hash(),
-                our_invoice.payment_hash()
-            ));
-        }
+    //     if lsp_invoice.payment_hash() != our_invoice.payment_hash() {
+    //         return Some(format!(
+    //             "Received invoice with wrong payment hash: {} != {}",
+    //             lsp_invoice.payment_hash(),
+    //             our_invoice.payment_hash()
+    //         ));
+    //     }
 
-        let invoice_pubkey = lsp_invoice.recover_payee_pub_key();
-        if invoice_pubkey != self.pubkey {
-            return Some(format!(
-                "Received invoice from wrong node: {invoice_pubkey} != {}",
-                self.pubkey
-            ));
-        }
+    //     let invoice_pubkey = lsp_invoice.recover_payee_pub_key();
+    //     if invoice_pubkey != self.pubkey {
+    //         return Some(format!(
+    //             "Received invoice from wrong node: {invoice_pubkey} != {}",
+    //             self.pubkey
+    //         ));
+    //     }
 
-        if lsp_invoice.amount_milli_satoshis().is_none() {
-            return Some("Invoice amount is missing".to_string());
-        }
+    //     if lsp_invoice.amount_milli_satoshis().is_none() {
+    //         return Some("Invoice amount is missing".to_string());
+    //     }
 
-        if our_invoice.amount_milli_satoshis().is_none() {
-            return Some("Invoice amount is missing".to_string());
-        }
+    //     if our_invoice.amount_milli_satoshis().is_none() {
+    //         return Some("Invoice amount is missing".to_string());
+    //     }
 
-        let lsp_invoice_amt = lsp_invoice.amount_milli_satoshis().expect("just checked");
-        let our_invoice_amt = our_invoice.amount_milli_satoshis().expect("just checked");
+    //     let lsp_invoice_amt = lsp_invoice.amount_milli_satoshis().expect("just checked");
+    //     let our_invoice_amt = our_invoice.amount_milli_satoshis().expect("just checked");
 
-        let expected_lsp_invoice_amt = our_invoice_amt + lsp_fee_msats;
+    //     let expected_lsp_invoice_amt = our_invoice_amt + lsp_fee_msats;
 
-        // verify invoice within 10 sats of our target
-        if lsp_invoice_amt.abs_diff(expected_lsp_invoice_amt) > 10_000 {
-            return Some(format!(
-                "Received invoice with wrong amount: {lsp_invoice_amt} when amount was {expected_lsp_invoice_amt}",
-            ));
-        }
+    //     // verify invoice within 10 sats of our target
+    //     if lsp_invoice_amt.abs_diff(expected_lsp_invoice_amt) > 10_000 {
+    //         return Some(format!(
+    //             "Received invoice with wrong amount: {lsp_invoice_amt} when amount was {expected_lsp_invoice_amt}",
+    //         ));
+    //     }
 
-        None
-    }
+    //     None
+    // }
 }
 
 /// Adds the x-auth-token header if needed

--- a/mutiny-core/src/lsp/voltage.rs
+++ b/mutiny-core/src/lsp/voltage.rs
@@ -398,193 +398,193 @@ impl Lsp for LspClient {
     }
 }
 
-#[cfg(test)]
-#[cfg(not(target_arch = "wasm32"))]
-mod test {
-    use crate::logging::MutinyLogger;
-    use crate::lsp::voltage::{LspClient, VoltageConfig};
-    use crate::test_utils::{create_dummy_invoice, create_dummy_invoice_with_payment_hash};
-    use bitcoin::hashes::{sha256, Hash};
-    use bitcoin::secp256k1::{Secp256k1, SecretKey};
-    use bitcoin::Network;
-    use futures::executor::block_on;
-    use std::sync::Arc;
+// #[cfg(test)]
+// #[cfg(not(target_arch = "wasm32"))]
+// mod test {
+//     use crate::logging::MutinyLogger;
+//     use crate::lsp::voltage::{LspClient, VoltageConfig};
+//     use crate::test_utils::{create_dummy_invoice, create_dummy_invoice_with_payment_hash};
+//     use bitcoin::hashes::{sha256, Hash};
+//     use bitcoin::secp256k1::{Secp256k1, SecretKey};
+//     use bitcoin::Network;
+//     use futures::executor::block_on;
+//     use std::sync::Arc;
 
-    #[test]
-    fn test_verify_invoice() {
-        let secret = SecretKey::from_slice(&[0x42; 32]).unwrap();
-        let pk = secret.public_key(&Secp256k1::new());
-        let client = block_on(LspClient::new(
-            VoltageConfig {
-                url: "http://localhost:8080".to_string(),
-                pubkey: Some(pk),
-                connection_string: Some(format!("{pk}@localhost:9735")),
-            },
-            Arc::new(MutinyLogger::default()),
-        ))
-        .unwrap();
+//     #[test]
+//     fn test_verify_invoice() {
+//         let secret = SecretKey::from_slice(&[0x42; 32]).unwrap();
+//         let pk = secret.public_key(&Secp256k1::new());
+//         let client = block_on(LspClient::new(
+//             VoltageConfig {
+//                 url: "http://localhost:8080".to_string(),
+//                 pubkey: Some(pk),
+//                 connection_string: Some(format!("{pk}@localhost:9735")),
+//             },
+//             Arc::new(MutinyLogger::default()),
+//         ))
+//         .unwrap();
 
-        let invoice_amount_msats = 100_000_000; // 100k sats
-        let lsp_fee_msat = 1_000; // 1 sat fee
-        let amount_minus_fee = invoice_amount_msats - lsp_fee_msat;
+//         let invoice_amount_msats = 100_000_000; // 100k sats
+//         let lsp_fee_msat = 1_000; // 1 sat fee
+//         let amount_minus_fee = invoice_amount_msats - lsp_fee_msat;
 
-        // we create our invoices with `amount_minus_fee` so we pay the fee, not the sender
-        let (our_invoice, preimage) =
-            create_dummy_invoice(Some(amount_minus_fee), Network::Regtest, None);
-        let payment_hash = sha256::Hash::hash(&preimage);
+//         // we create our invoices with `amount_minus_fee` so we pay the fee, not the sender
+//         let (our_invoice, preimage) =
+//             create_dummy_invoice(Some(amount_minus_fee), Network::Regtest, None);
+//         let payment_hash = sha256::Hash::hash(&preimage);
 
-        // check good invoice
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        assert!(client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .is_none());
+//         // check good invoice
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         assert!(client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .is_none());
 
-        // check invoice wrong network
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats),
-            Network::Bitcoin,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice on wrong network"));
+//         // check invoice wrong network
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats),
+//             Network::Bitcoin,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice on wrong network"));
 
-        // check invoice wrong payment_hash
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats),
-            Network::Regtest,
-            Some(secret),
-            sha256::Hash::all_zeros(),
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice with wrong payment hash"));
+//         // check invoice wrong payment_hash
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats),
+//             Network::Regtest,
+//             Some(secret),
+//             sha256::Hash::all_zeros(),
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice with wrong payment hash"));
 
-        // check invoice wrong key
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats),
-            Network::Regtest,
-            None,
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice from wrong node"));
+//         // check invoice wrong key
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats),
+//             Network::Regtest,
+//             None,
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice from wrong node"));
 
-        // check invoice no amount
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            None,
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Invoice amount is missing"));
+//         // check invoice no amount
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             None,
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Invoice amount is missing"));
 
-        // check invoice amount way too low
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(1),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice with wrong amount"));
+//         // check invoice amount way too low
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(1),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice with wrong amount"));
 
-        // check invoice amount way too high
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats * 10),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice with wrong amount"));
+//         // check invoice amount way too high
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats * 10),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice with wrong amount"));
 
-        // check invoice amount small difference
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats + 10_001),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice with wrong amount"));
+//         // check invoice amount small difference
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats + 10_001),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice with wrong amount"));
 
-        // check invoice amount small difference
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats - 10_001),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice with wrong amount"));
+//         // check invoice amount small difference
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats - 10_001),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice with wrong amount"));
 
-        // change fee to 10k sats
-        let lsp_fee_msat = 10_000_000; // 10k sats fee
-        let amount_minus_fee = invoice_amount_msats - lsp_fee_msat;
+//         // change fee to 10k sats
+//         let lsp_fee_msat = 10_000_000; // 10k sats fee
+//         let amount_minus_fee = invoice_amount_msats - lsp_fee_msat;
 
-        // we create our invoices with `amount_minus_fee` so we pay the fee, not the sender
-        let (our_invoice, preimage) =
-            create_dummy_invoice(Some(amount_minus_fee), Network::Regtest, None);
-        let payment_hash = sha256::Hash::hash(&preimage);
+//         // we create our invoices with `amount_minus_fee` so we pay the fee, not the sender
+//         let (our_invoice, preimage) =
+//             create_dummy_invoice(Some(amount_minus_fee), Network::Regtest, None);
+//         let payment_hash = sha256::Hash::hash(&preimage);
 
-        // check good invoice
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(invoice_amount_msats),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        assert!(client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .is_none());
+//         // check good invoice
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(invoice_amount_msats),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         assert!(client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .is_none());
 
-        // check invoice amount small difference
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(amount_minus_fee + 10_001),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice with wrong amount"));
+//         // check invoice amount small difference
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(amount_minus_fee + 10_001),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice with wrong amount"));
 
-        // check invoice amount small difference
-        let lsp_invoice = create_dummy_invoice_with_payment_hash(
-            Some(amount_minus_fee - 10_001),
-            Network::Regtest,
-            Some(secret),
-            payment_hash,
-        );
-        let err = client
-            .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
-            .unwrap();
-        assert!(err.contains("Received invoice with wrong amount"));
-    }
-}
+//         // check invoice amount small difference
+//         let lsp_invoice = create_dummy_invoice_with_payment_hash(
+//             Some(amount_minus_fee - 10_001),
+//             Network::Regtest,
+//             Some(secret),
+//             payment_hash,
+//         );
+//         let err = client
+//             .verify_invoice(&our_invoice, &lsp_invoice, lsp_fee_msat)
+//             .unwrap();
+//         assert!(err.contains("Received invoice with wrong amount"));
+//     }
+// }
 
 #[cfg(test)]
 #[cfg(target_arch = "wasm32")]

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1,4 +1,4 @@
-use crate::lsp::{InvoiceRequest, LspConfig};
+use crate::lsp::LspConfig;
 use crate::nodemanager::ChannelClosure;
 use crate::peermanager::LspMessageRouter;
 use crate::storage::MutinyStorage;
@@ -1214,151 +1214,164 @@ impl<S: MutinyStorage> Node<S> {
     ) -> Result<(Bolt11Invoice, u64), MutinyError> {
         log_trace!(self.logger, "calling create_invoice");
 
-        let res = match self.lsp_client.as_ref() {
-            Some(lsp) => {
-                let connect = lsp.get_lsp_connection_string().await;
-                self.connect_peer(PubkeyConnectionInfo::new(&connect)?, None)
-                    .await?;
+        let res = Ok((
+            self.create_internal_invoice(
+                Some(amount_sat),
+                None,
+                route_hints,
+                labels,
+                expiry_delta_secs,
+            )
+            .await?,
+            0,
+        ));
 
-                // Needs any amount over 0 if channel exists
-                // Needs amount over minimum if no channel
-                let lsp_pubkey = lsp.get_lsp_pubkey().await;
-                let inbound_capacity_msat: u64 = self
-                    .channel_manager
-                    .list_channels_with_counterparty(&lsp_pubkey)
-                    .iter()
-                    .map(|c| c.inbound_capacity_msat)
-                    .sum();
+        // TODO: Skip LSP fee and invoice checking
+        // let res = match self.lsp_client.as_ref() {
+        //     Some(lsp) => {
+        //         let connect = lsp.get_lsp_connection_string().await;
+        //         self.connect_peer(PubkeyConnectionInfo::new(&connect)?, None)
+        //             .await?;
 
-                log_debug!(self.logger, "Current inbound liquidity {inbound_capacity_msat}msats, creating invoice for {}msats", amount_sat * 1000);
+        //         // Needs any amount over 0 if channel exists
+        //         // Needs amount over minimum if no channel
+        //         let lsp_pubkey = lsp.get_lsp_pubkey().await;
+        //         let inbound_capacity_msat: u64 = self
+        //             .channel_manager
+        //             .list_channels_with_counterparty(&lsp_pubkey)
+        //             .iter()
+        //             .map(|c| c.inbound_capacity_msat)
+        //             .sum();
 
-                let has_inbound_capacity = inbound_capacity_msat > amount_sat * 1_000;
+        //         log_debug!(self.logger, "Current inbound liquidity {inbound_capacity_msat}msats, creating invoice for {}msats", amount_sat * 1000);
 
-                let min_amount_sat = if has_inbound_capacity {
-                    1
-                } else {
-                    utils::min_lightning_amount(self.network, lsp.is_lsps())
-                };
+        //         let has_inbound_capacity = inbound_capacity_msat > amount_sat * 1_000;
 
-                if amount_sat < min_amount_sat {
-                    return Err(MutinyError::BadAmountError);
-                }
+        //         let min_amount_sat = if has_inbound_capacity {
+        //             1
+        //         } else {
+        //             utils::min_lightning_amount(self.network, lsp.is_lsps())
+        //         };
 
-                match lsp {
-                    AnyLsp::VoltageFlow(lock) => {
-                        // check the fee from the LSP
-                        let lsp_fee = lsp
-                            .get_lsp_fee_msat(FeeRequest {
-                                pubkey: self.pubkey.encode().to_lower_hex_string(),
-                                amount_msat: amount_sat * 1000,
-                            })
-                            .await?;
+        //         if amount_sat < min_amount_sat {
+        //             return Err(MutinyError::BadAmountError);
+        //         }
 
-                        // Convert the fee from msat to sat for comparison and subtraction
-                        let lsp_fee_sat = lsp_fee.fee_amount_msat / 1000;
+        //         match lsp {
+        //             AnyLsp::VoltageFlow(lock) => {
+        //                 // check the fee from the LSP
+        //                 let lsp_fee = lsp
+        //                     .get_lsp_fee_msat(FeeRequest {
+        //                         pubkey: self.pubkey.encode().to_lower_hex_string(),
+        //                         amount_msat: amount_sat * 1000,
+        //                     })
+        //                     .await?;
 
-                        // Ensure that the fee is less than the amount being requested.
-                        // If it isn't, we don't subtract it.
-                        // This prevents amount from being subtracted down to 0.
-                        // This will mean that the LSP fee will be paid by the payer instead.
-                        let amount_minus_fee = if lsp_fee_sat < amount_sat {
-                            amount_sat
-                                .checked_sub(lsp_fee_sat)
-                                .ok_or(MutinyError::BadAmountError)?
-                        } else {
-                            amount_sat
-                        };
-                        let client = lock.read().await;
-                        let invoice = self
-                            .create_internal_invoice(
-                                Some(amount_minus_fee),
-                                Some(lsp_fee.fee_amount_msat),
-                                route_hints,
-                                labels,
-                                expiry_delta_secs,
-                            )
-                            .await?;
+        //                 // Convert the fee from msat to sat for comparison and subtraction
+        //                 let lsp_fee_sat = lsp_fee.fee_amount_msat / 1000;
 
-                        let lsp_invoice = client
-                            .get_lsp_invoice(InvoiceRequest {
-                                bolt11: Some(invoice.to_string()),
-                                fee_id: lsp_fee.id,
-                            })
-                            .await?;
+        //                 // Ensure that the fee is less than the amount being requested.
+        //                 // If it isn't, we don't subtract it.
+        //                 // This prevents amount from being subtracted down to 0.
+        //                 // This will mean that the LSP fee will be paid by the payer instead.
+        //                 let amount_minus_fee = if lsp_fee_sat < amount_sat {
+        //                     amount_sat
+        //                         .checked_sub(lsp_fee_sat)
+        //                         .ok_or(MutinyError::BadAmountError)?
+        //                 } else {
+        //                     amount_sat
+        //                 };
+        //                 let client = lock.read().await;
+        //                 let invoice = self
+        //                     .create_internal_invoice(
+        //                         Some(amount_minus_fee),
+        //                         Some(lsp_fee.fee_amount_msat),
+        //                         route_hints,
+        //                         labels,
+        //                         expiry_delta_secs,
+        //                     )
+        //                     .await?;
 
-                        if let Some(error) =
-                            client.verify_invoice(&invoice, &lsp_invoice, lsp_fee.fee_amount_msat)
-                        {
-                            log_error!(self.logger, "{error}");
-                            return Err(MutinyError::InvoiceCreationFailed);
-                        }
+        //                 let lsp_invoice = client
+        //                     .get_lsp_invoice(InvoiceRequest {
+        //                         bolt11: Some(invoice.to_string()),
+        //                         fee_id: lsp_fee.id,
+        //                     })
+        //                     .await?;
 
-                        log_debug!(self.logger, "Got wrapped invoice from LSP: {lsp_invoice}");
+        //                 if let Some(error) =
+        //                     client.verify_invoice(&invoice, &lsp_invoice, lsp_fee.fee_amount_msat)
+        //                 {
+        //                     log_error!(self.logger, "{error}");
+        //                     return Err(MutinyError::InvoiceCreationFailed);
+        //                 }
 
-                        Ok((lsp_invoice, lsp_fee_sat))
-                    }
-                    AnyLsp::Lsps(client) => {
-                        if has_inbound_capacity {
-                            Ok((
-                                self.create_internal_invoice(
-                                    Some(amount_sat),
-                                    None,
-                                    route_hints,
-                                    labels,
-                                    expiry_delta_secs,
-                                )
-                                .await?,
-                                0,
-                            ))
-                        } else {
-                            // check the fee from the LSP
-                            let lsp_fee = lsp
-                                .get_lsp_fee_msat(FeeRequest {
-                                    pubkey: self.pubkey.encode().to_lower_hex_string(),
-                                    amount_msat: amount_sat * 1000,
-                                })
-                                .await?;
+        //                 log_debug!(self.logger, "Got wrapped invoice from LSP: {lsp_invoice}");
 
-                            let lsp_invoice = match client
-                                .get_lsp_invoice(InvoiceRequest {
-                                    bolt11: None,
-                                    fee_id: lsp_fee.id,
-                                })
-                                .await
-                            {
-                                Ok(invoice) => {
-                                    self.save_invoice_payment_info(
-                                        invoice.clone(),
-                                        Some(amount_sat * 1_000),
-                                        Some(lsp_fee.fee_amount_msat),
-                                        labels,
-                                    )
-                                    .await?;
+        //                 Ok((lsp_invoice, lsp_fee_sat))
+        //             }
+        //             AnyLsp::Lsps(client) => {
+        //                 if has_inbound_capacity {
+        //                     Ok((
+        //                         self.create_internal_invoice(
+        //                             Some(amount_sat),
+        //                             None,
+        //                             route_hints,
+        //                             labels,
+        //                             expiry_delta_secs,
+        //                         )
+        //                         .await?,
+        //                         0,
+        //                     ))
+        //                 } else {
+        //                     // check the fee from the LSP
+        //                     let lsp_fee = lsp
+        //                         .get_lsp_fee_msat(FeeRequest {
+        //                             pubkey: self.pubkey.encode().to_lower_hex_string(),
+        //                             amount_msat: amount_sat * 1000,
+        //                         })
+        //                         .await?;
 
-                                    invoice
-                                }
-                                Err(e) => {
-                                    log_error!(self.logger, "Failed to get invoice from LSP: {e}");
-                                    return Err(e);
-                                }
-                            };
-                            Ok((lsp_invoice, 0))
-                        }
-                    }
-                }
-            }
-            None => Ok((
-                self.create_internal_invoice(
-                    Some(amount_sat),
-                    None,
-                    route_hints,
-                    labels,
-                    expiry_delta_secs,
-                )
-                .await?,
-                0,
-            )),
-        };
+        //                     let lsp_invoice = match client
+        //                         .get_lsp_invoice(InvoiceRequest {
+        //                             bolt11: None,
+        //                             fee_id: lsp_fee.id,
+        //                         })
+        //                         .await
+        //                     {
+        //                         Ok(invoice) => {
+        //                             self.save_invoice_payment_info(
+        //                                 invoice.clone(),
+        //                                 Some(amount_sat * 1_000),
+        //                                 Some(lsp_fee.fee_amount_msat),
+        //                                 labels,
+        //                             )
+        //                             .await?;
+
+        //                             invoice
+        //                         }
+        //                         Err(e) => {
+        //                             log_error!(self.logger, "Failed to get invoice from LSP: {e}");
+        //                             return Err(e);
+        //                         }
+        //                     };
+        //                     Ok((lsp_invoice, 0))
+        //                 }
+        //             }
+        //         }
+        //     }
+        //     None => Ok((
+        //         self.create_internal_invoice(
+        //             Some(amount_sat),
+        //             None,
+        //             route_hints,
+        //             labels,
+        //             expiry_delta_secs,
+        //         )
+        //         .await?,
+        //         0,
+        //     )),
+        // };
         log_trace!(self.logger, "finished calling create_invoice");
 
         res

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1414,6 +1414,7 @@ impl<S: MutinyStorage> NodeManager<S> {
         &self,
         amount: u64,
         labels: Vec<String>,
+        expiry_delta_secs: Option<u32>,
     ) -> Result<(MutinyInvoice, u64), MutinyError> {
         log_trace!(self.logger, "calling create_invoice");
 
@@ -1440,7 +1441,7 @@ impl<S: MutinyStorage> NodeManager<S> {
             return Err(MutinyError::WalletOperationFailed);
         };
         let invoice = first_node
-            .create_invoice(amount, route_hints, labels)
+            .create_invoice(amount, route_hints, labels, expiry_delta_secs)
             .await?;
         log_trace!(self.logger, "finished calling create_invoice");
 

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.9.7"
+version = "1.9.8"
 edition = "2021"
 authors = ["Tony Giorgio <tony@mutinywallet.com>", "benthecarman <ben@mutinywallet.com>"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.9.1"
+version = "1.9.3"
 edition = "2021"
 authors = ["Tony Giorgio <tony@mutinywallet.com>", "benthecarman <ben@mutinywallet.com>"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.7.13"
+version = "1.9.1"
 edition = "2021"
 authors = ["Tony Giorgio <tony@mutinywallet.com>", "benthecarman <ben@mutinywallet.com>"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.9.3"
+version = "1.9.7"
 edition = "2021"
 authors = ["Tony Giorgio <tony@mutinywallet.com>", "benthecarman <ben@mutinywallet.com>"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -400,7 +400,8 @@ impl MutinyWallet {
     /// Returns after node has been stopped.
     #[wasm_bindgen]
     pub async fn stop(&self) -> Result<(), MutinyJsError> {
-        Ok(self.inner.node_manager.stop().await?)
+        // Ok(self.inner.node_manager.stop().await?)
+        Ok(self.inner.stop().await?)
     }
 
     /// Returns the mnemonic seed phrase for the wallet.

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -725,9 +725,14 @@ impl MutinyWallet {
     pub async fn create_invoice(
         &self,
         amount: u64,
-        labels: Vec<String>,
+        label: String,
+        expiry_delta_secs: Option<u32>,
     ) -> Result<MutinyInvoice, MutinyJsError> {
-        Ok(self.inner.create_invoice(amount, labels).await?.into())
+        Ok(self
+            .inner
+            .create_invoice(amount, vec![label], expiry_delta_secs)
+            .await?
+            .into())
     }
 
     /// Pays a lightning invoice from the selected node.


### PR DESCRIPTION
## Changes

- Accept zero-confirmation channel when matched LSP pubkey
- Custom label and expiry for invoice
- Skip LSP invoice verifying
