### PR TITLE
Broadcast peer event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,7 @@ dependencies = [
  "once_cell",
  "rexie",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
  "urlencoding",
@@ -1989,6 +1990,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -4,7 +4,10 @@ cargo-features = ["per-package-target"]
 name = "mutiny-core"
 version = "1.7.13"
 edition = "2021"
-authors = ["Tony Giorgio <tony@mutinywallet.com>", "benthecarman <ben@mutinywallet.com>"]
+authors = [
+  "Tony Giorgio <tony@mutinywallet.com>",
+  "benthecarman <ben@mutinywallet.com>",
+]
 description = "The core SDK for the mutiny node"
 license = "MIT"
 documentation = "https://docs.rs/mutiny-core"
@@ -14,8 +17,16 @@ repository = "https://github.com/mutinywallet/mutiny-node"
 [dependencies]
 cfg-if = "1.0.0"
 bip39 = { version = "2.0.0" }
-bitcoin = { version = "0.32.2", default-features = false, features = ["std", "serde", "secp-recovery", "rand"] }
-bdk_esplora = { version = "=0.18.0", default-features = false, features = ["std", "async-https"] }
+bitcoin = { version = "0.32.2", default-features = false, features = [
+  "std",
+  "serde",
+  "secp-recovery",
+  "rand",
+] }
+bdk_esplora = { version = "=0.18.0", default-features = false, features = [
+  "std",
+  "async-https",
+] }
 bdk_chain = { version = "=0.19.0", features = ["std"] }
 bdk_wallet = { version = "=1.0.0-beta.4", features = ["std"] }
 bdk-macros = "0.6.0"
@@ -24,16 +35,27 @@ itertools = "0.11.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 uuid = { version = "1.1.2", features = ["v4"] }
-esplora-client = { version = "0.9", default-features = false, features = ["async"] }
-lightning = { version = "0.0.124", default-features = false, features = ["max_level_trace", "grind_signatures", "std"] }
+esplora-client = { version = "0.9", default-features = false, features = [
+  "async",
+] }
+lightning = { version = "0.0.124", default-features = false, features = [
+  "max_level_trace",
+  "grind_signatures",
+  "std",
+] }
 lightning-invoice = { version = "0.32.0", features = ["serde"] }
 lightning-rapid-gossip-sync = { version = "0.0.124" }
 lightning-background-processor = { version = "0.0.124", features = ["futures"] }
-lightning-transaction-sync = { version = "0.0.124", default-features = false, features = ["esplora-async-https"] }
+lightning-transaction-sync = { version = "0.0.124", default-features = false, features = [
+  "esplora-async-https",
+] }
 lightning-liquidity = "0.1.0-alpha.5"
 chrono = "0.4.22"
 futures-util = { version = "0.3", default-features = false }
-reqwest = { version = "0.11", default-features = false, features = ["multipart", "json"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "multipart",
+  "json",
+] }
 async-trait = "0.1.68"
 url = { version = "2.3.1", features = ["serde"] }
 cbc = { version = "0.1", features = ["alloc"] }
@@ -69,6 +91,8 @@ gloo-net = { version = "0.4.0" }
 web-time = "1.1"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 getrandom = { version = "0.2", features = ["js"] }
+web-sys = { version = "0.3.65", features = ["console"] }
+js-sys = "0.3.65"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -79,7 +79,7 @@ use lightning::{log_debug, log_error, log_info, log_trace, log_warn};
 pub use lightning_invoice;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription};
 
-use messagehandler::ChannelEventCallback;
+use messagehandler::PeerEventCallback;
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashSet;
@@ -660,7 +660,7 @@ pub struct MutinyWalletBuilder<S: MutinyStorage> {
     network: Option<Network>,
     blind_auth_url: Option<String>,
     hermes_url: Option<String>,
-    channel_event_callback: Option<ChannelEventCallback>,
+    peer_event_callback: Option<PeerEventCallback>,
     subscription_url: Option<String>,
     do_not_connect_peers: bool,
     skip_hodl_invoices: bool,
@@ -679,7 +679,7 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
             subscription_url: None,
             blind_auth_url: None,
             hermes_url: None,
-            channel_event_callback: None,
+            peer_event_callback: None,
             do_not_connect_peers: false,
             skip_device_lock: false,
             safe_mode: false,
@@ -720,8 +720,8 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
         self.hermes_url = Some(hermes_url);
     }
 
-    pub fn with_channel_event_callback(&mut self, cb: ChannelEventCallback) {
-        self.channel_event_callback = Some(cb);
+    pub fn with_peer_event_callback(&mut self, cb: PeerEventCallback) {
+        self.peer_event_callback = Some(cb);
     }
 
     pub fn do_not_connect_peers(&mut self) {
@@ -821,8 +821,8 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
             .with_config(config.clone());
         nm_builder.with_logger(logger.clone());
         nm_builder.with_esplora(esplora.clone());
-        if let Some(cb) = self.channel_event_callback.clone() {
-            nm_builder.with_channel_event_callback(cb);
+        if let Some(cb) = self.peer_event_callback.clone() {
+            nm_builder.with_peer_event_callback(cb);
         }
         let node_manager = Arc::new(nm_builder.build().await?);
 

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1,4 +1,5 @@
 use crate::lsp::LspConfig;
+use crate::messagehandler::ChannelEventCallback;
 use crate::nodemanager::ChannelClosure;
 use crate::peermanager::{LspMessageRouter, PeerManager};
 use crate::storage::MutinyStorage;
@@ -197,6 +198,7 @@ pub struct NodeBuilder<S: MutinyStorage> {
     fee_estimator: Option<Arc<MutinyFeeEstimator<S>>>,
     wallet: Option<Arc<OnChainWallet<S>>>,
     esplora: Option<Arc<AsyncClient>>,
+    channel_event_callback: Option<ChannelEventCallback>,
     #[cfg(target_arch = "wasm32")]
     websocket_proxy_addr: Option<String>,
     network: Option<Network>,
@@ -222,6 +224,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             wallet: None,
             esplora: None,
             has_done_initial_sync: None,
+            channel_event_callback: None,
             #[cfg(target_arch = "wasm32")]
             websocket_proxy_addr: None,
             lsp_config: None,
@@ -303,6 +306,10 @@ impl<S: MutinyStorage> NodeBuilder<S> {
 
     pub fn with_lsp_config(&mut self, lsp_config: LspConfig) {
         self.lsp_config = Some(lsp_config);
+    }
+
+    pub fn with_channel_event_callback(&mut self, callback: ChannelEventCallback) {
+        self.channel_event_callback = Some(callback);
     }
 
     pub fn with_logger(&mut self, logger: Arc<MutinyLogger>) {
@@ -567,6 +574,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             onion_message_handler: onion_message_handler.clone(),
             custom_message_handler: Arc::new(MutinyMessageHandler {
                 liquidity: liquidity.clone(),
+                channel_event_callback: self.channel_event_callback.clone(),
             }),
         };
         log_trace!(logger, "finished creating peer manager");

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1,5 +1,5 @@
 use crate::lsp::LspConfig;
-use crate::messagehandler::ChannelEventCallback;
+use crate::messagehandler::PeerEventCallback;
 use crate::nodemanager::ChannelClosure;
 use crate::peermanager::{LspMessageRouter, PeerManager};
 use crate::storage::MutinyStorage;
@@ -198,7 +198,7 @@ pub struct NodeBuilder<S: MutinyStorage> {
     fee_estimator: Option<Arc<MutinyFeeEstimator<S>>>,
     wallet: Option<Arc<OnChainWallet<S>>>,
     esplora: Option<Arc<AsyncClient>>,
-    channel_event_callback: Option<ChannelEventCallback>,
+    peer_event_callback: Option<PeerEventCallback>,
     #[cfg(target_arch = "wasm32")]
     websocket_proxy_addr: Option<String>,
     network: Option<Network>,
@@ -224,7 +224,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             wallet: None,
             esplora: None,
             has_done_initial_sync: None,
-            channel_event_callback: None,
+            peer_event_callback: None,
             #[cfg(target_arch = "wasm32")]
             websocket_proxy_addr: None,
             lsp_config: None,
@@ -308,8 +308,8 @@ impl<S: MutinyStorage> NodeBuilder<S> {
         self.lsp_config = Some(lsp_config);
     }
 
-    pub fn with_channel_event_callback(&mut self, callback: ChannelEventCallback) {
-        self.channel_event_callback = Some(callback);
+    pub fn with_peer_event_callback(&mut self, callback: PeerEventCallback) {
+        self.peer_event_callback = Some(callback);
     }
 
     pub fn with_logger(&mut self, logger: Arc<MutinyLogger>) {
@@ -574,7 +574,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             onion_message_handler: onion_message_handler.clone(),
             custom_message_handler: Arc::new(MutinyMessageHandler {
                 liquidity: liquidity.clone(),
-                channel_event_callback: self.channel_event_callback.clone(),
+                peer_event_callback: self.peer_event_callback.clone(),
             }),
         };
         log_trace!(logger, "finished creating peer manager");

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2,7 +2,7 @@ use crate::labels::LabelStorage;
 use crate::ldkstorage::CHANNEL_CLOSURE_PREFIX;
 use crate::logging::LOGGING_KEY;
 use crate::lsp::voltage;
-use crate::messagehandler::ChannelEventCallback;
+use crate::messagehandler::PeerEventCallback;
 use crate::peermanager::PeerManager;
 use crate::utils::{sleep, spawn};
 use crate::MutinyInvoice;
@@ -246,7 +246,7 @@ pub struct NodeManagerBuilder<S: MutinyStorage> {
     config: Option<MutinyWalletConfig>,
     stop: Option<Arc<AtomicBool>>,
     logger: Option<Arc<MutinyLogger>>,
-    channel_event_callback: Option<ChannelEventCallback>,
+    peer_event_callback: Option<PeerEventCallback>,
 }
 
 impl<S: MutinyStorage> NodeManagerBuilder<S> {
@@ -258,7 +258,7 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             config: None,
             stop: None,
             logger: None,
-            channel_event_callback: None,
+            peer_event_callback: None,
         }
     }
 
@@ -275,8 +275,8 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
         self.esplora = Some(esplora);
     }
 
-    pub fn with_channel_event_callback(&mut self, cb: ChannelEventCallback) {
-        self.channel_event_callback = Some(cb);
+    pub fn with_peer_event_callback(&mut self, cb: PeerEventCallback) {
+        self.peer_event_callback = Some(cb);
     }
 
     pub fn with_logger(&mut self, logger: Arc<MutinyLogger>) {
@@ -418,8 +418,8 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
                 if let Some(l) = lsp_config.clone() {
                     node_builder.with_lsp_config(l);
                 }
-                if let Some(cb) = self.channel_event_callback.clone() {
-                    node_builder.with_channel_event_callback(cb);
+                if let Some(cb) = self.peer_event_callback.clone() {
+                    node_builder.with_peer_event_callback(cb);
                 }
                 if c.do_not_connect_peers {
                     node_builder.do_not_connect_peers();
@@ -493,7 +493,7 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             websocket_proxy_addr,
             user_rgs_url: c.user_rgs_url,
             esplora,
-            channel_event_callback: self.channel_event_callback,
+            peer_event_callback: self.peer_event_callback,
             lsp_config,
             logger,
             do_not_connect_peers: c.do_not_connect_peers,
@@ -520,7 +520,7 @@ pub struct NodeManager<S: MutinyStorage> {
     websocket_proxy_addr: String,
     user_rgs_url: Option<String>,
     esplora: Arc<AsyncClient>,
-    channel_event_callback: Option<ChannelEventCallback>,
+    peer_event_callback: Option<PeerEventCallback>,
     pub(crate) wallet: Arc<OnChainWallet<S>>,
     gossip_sync: Arc<RapidGossipSync>,
     scorer: Arc<utils::Mutex<HubPreferentialScorer>>,
@@ -1963,8 +1963,8 @@ pub(crate) async fn create_new_node_from_node_manager<S: MutinyStorage>(
     if let Some(l) = node_manager.lsp_config.clone() {
         node_builder.with_lsp_config(l);
     }
-    if let Some(cb) = node_manager.channel_event_callback.clone() {
-        node_builder.with_channel_event_callback(cb);
+    if let Some(cb) = node_manager.peer_event_callback.clone() {
+        node_builder.with_peer_event_callback(cb);
     }
     if node_manager.do_not_connect_peers {
         node_builder.do_not_connect_peers();

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -4,7 +4,10 @@ cargo-features = ["per-package-target"]
 name = "mutiny-wasm"
 version = "1.9.8"
 edition = "2021"
-authors = ["Tony Giorgio <tony@mutinywallet.com>", "benthecarman <ben@mutinywallet.com>"]
+authors = [
+  "Tony Giorgio <tony@mutinywallet.com>",
+  "benthecarman <ben@mutinywallet.com>",
+]
 forced-target = "wasm32-unknown-unknown"
 description = "A wasm-bindgen wrapper around mutiny-core"
 license = "MIT"
@@ -22,18 +25,26 @@ anyhow = "1.0"
 async-trait = "0.1.68"
 wasm-bindgen = "0.2.91"
 wasm-bindgen-futures = "0.4.38"
+serde-wasm-bindgen = "0.6"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 base64 = "0.13.1"
-bitcoin = { version = "0.32.2", default-features = false, features = ["std", "serde", "secp-recovery", "rand"] }
-lightning = { version = "0.0.124", default-features = false, features = ["std"] }
+bitcoin = { version = "0.32.2", default-features = false, features = [
+  "std",
+  "serde",
+  "secp-recovery",
+  "rand",
+] }
+lightning = { version = "0.0.124", default-features = false, features = [
+  "std",
+] }
 lightning-invoice = { version = "0.32.0" }
 thiserror = "1.0"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-log = {version = "0.4.17", features = ["std"]}
+log = { version = "0.4.17", features = ["std"] }
 rexie = "0.5.0"
 gloo-utils = { version = "0.2.0", features = ["serde"] }
-web-sys = { version = "0.3.60", features = ["console"] }
+web-sys = { version = "0.3.60", features = ["console", "BroadcastChannel"] }
 bip39 = { version = "2.0.0" }
 getrandom = { version = "0.2", features = ["js"] }
 futures = "0.3.25"

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -116,16 +116,14 @@ impl MutinyWallet {
             callback: Arc::new(move |event| {
                 const KEY: &str = "peer_connection_event_broadcast_channel";
                 let global = web_sys::js_sys::global();
-                let channel: BroadcastChannel =
-                    match web_sys::js_sys::Reflect::get(&global, &(KEY.into())) {
-                        Ok(channel) => channel.dyn_into().unwrap(),
-                        Err(_) => {
-                            let channel = web_sys::BroadcastChannel::new(&topic).unwrap();
-                            web_sys::js_sys::Reflect::set(&global, &(KEY.into()), &channel)
-                                .unwrap();
-                            channel
-                        }
-                    };
+                let value = web_sys::js_sys::Reflect::get(&global, &(KEY.into())).unwrap();
+                let channel: BroadcastChannel = if value.is_undefined() {
+                    let channel = web_sys::BroadcastChannel::new(&topic).unwrap();
+                    web_sys::js_sys::Reflect::set(&global, &(KEY.into()), &channel).unwrap();
+                    channel
+                } else {
+                    value.dyn_into().unwrap()
+                };
                 let event = serde_wasm_bindgen::to_value(&event).expect("convert to js");
                 channel.post_message(&event).unwrap();
             }),


### PR DESCRIPTION
### Usage

1. In `MutinyNode::new` remove arg `primal_api`, then append a new arg “event topic” at the last position

``` typescript
-    // primal URL
-    primal_api || 'https://primal-cache.mutinywallet.com/api',
     /// blind auth url
     blind_auth,
     /// hermes url
-    hermes
+    hermes,
+    "ln_node_event"
```

2 subscribe the topic

``` typescript

 const Test = () => {
   const worker = useBtcLnWorker()
 
   const channel = new BroadcastChannel("ln_node_event");
   channel.onmessage = (e) => {
     console.log("peer event from worker", e);
   }
   window.ln_node_event_channel = channel;
```