### PR TITLE
refactor storage, wait all tasks before stopped

### DIFF
--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -159,7 +159,7 @@ fn write_gossip_data(
     _network_graph: &NetworkGraph,
 ) -> Result<(), MutinyError> {
     // Save the last sync timestamp
-    storage.set_data(GOSSIP_SYNC_TIME_KEY.to_string(), last_sync_timestamp, None)?;
+    storage.write_data(GOSSIP_SYNC_TIME_KEY.to_string(), last_sync_timestamp, None)?;
 
     // Save the network graph
     // skip for now, we don't read it currently
@@ -411,7 +411,7 @@ pub(crate) fn save_peer_connection_info(
         },
     };
 
-    storage.set_data(key, new_info, None)?;
+    storage.write_data(key, new_info, None)?;
     Ok(())
 }
 
@@ -437,7 +437,7 @@ pub(crate) fn set_peer_label(
         },
     };
 
-    storage.set_data(key, new_info, None)?;
+    storage.write_data(key, new_info, None)?;
     Ok(())
 }
 
@@ -455,7 +455,7 @@ pub(crate) fn delete_peer_info(
         if current.nodes.is_empty() {
             storage.delete(&[key])?;
         } else {
-            storage.set_data(key, current, None)?;
+            storage.write_data(key, current, None)?;
         }
     }
 
@@ -475,7 +475,7 @@ pub(crate) fn save_ln_peer_info(
 
     // if the new info is different than the current info, we should to save it
     if !current.is_some_and(|c| c == new_info) {
-        storage.set_data(key, new_info, None)?;
+        storage.write_data(key, new_info, None)?;
     }
 
     Ok(())

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -942,8 +942,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
                             object,
                             Some(version),
                             retry_logger.clone(),
-                        )
-                        .await;
+                        );
 
                         match res {
 							Ok(_) => {

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -94,7 +94,7 @@ impl<S: MutinyStorage> OnChainWallet<S> {
             Some(Err(bdk_wallet::LoadError::Mismatch(_))) => {
                 // failed to read storage, means we have old encoding and need to delete and re-init wallet
                 db.delete(&[KEYCHAIN_STORE_KEY])?;
-                db.set_data(NEED_FULL_SYNC_KEY.to_string(), true, None)?;
+                db.write_data(NEED_FULL_SYNC_KEY.to_string(), true, None)?;
                 Wallet::create_with_params(
                     CreateParams::new(receive_descriptor_template, change_descriptor_template)
                         .network(network),


### PR DESCRIPTION
1. rename DB operations
2. remove async version DB `write` since we can't blocking a future in browser.
    * rust-lightning interface do not allows async function, so we can only use synced version DB write.
4. wait all DB tasks end before storage stopped.