### PR TITLE
break: Support option to disable bump transaction for close channel tx

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -522,6 +522,7 @@ pub struct MutinyWalletConfigBuilder {
     blind_auth_url: Option<String>,
     hermes_url: Option<String>,
     do_not_connect_peers: bool,
+    do_not_bump_channel_close_tx: bool,
     skip_device_lock: bool,
     pub safe_mode: bool,
     skip_hodl_invoices: bool,
@@ -543,6 +544,7 @@ impl MutinyWalletConfigBuilder {
             blind_auth_url: None,
             hermes_url: None,
             do_not_connect_peers: false,
+            do_not_bump_channel_close_tx: false,
             skip_device_lock: false,
             safe_mode: false,
             skip_hodl_invoices: true,
@@ -596,6 +598,10 @@ impl MutinyWalletConfigBuilder {
         self.do_not_connect_peers = true;
     }
 
+    pub fn do_not_bump_channel_close_tx(&mut self) {
+        self.do_not_bump_channel_close_tx = true;
+    }
+
     pub fn with_skip_device_lock(&mut self) {
         self.skip_device_lock = true;
     }
@@ -626,6 +632,7 @@ impl MutinyWalletConfigBuilder {
             blind_auth_url: self.blind_auth_url,
             hermes_url: self.hermes_url,
             do_not_connect_peers: self.do_not_connect_peers,
+            do_not_bump_channel_close_tx: self.do_not_bump_channel_close_tx,
             skip_device_lock: self.skip_device_lock,
             safe_mode: self.safe_mode,
             skip_hodl_invoices: self.skip_hodl_invoices,
@@ -648,6 +655,7 @@ pub struct MutinyWalletConfig {
     blind_auth_url: Option<String>,
     hermes_url: Option<String>,
     do_not_connect_peers: bool,
+    do_not_bump_channel_close_tx: bool,
     skip_device_lock: bool,
     pub safe_mode: bool,
     skip_hodl_invoices: bool,
@@ -664,6 +672,7 @@ pub struct MutinyWalletBuilder<S: MutinyStorage> {
     peer_event_callback: Option<PeerEventCallback>,
     subscription_url: Option<String>,
     do_not_connect_peers: bool,
+    do_not_bump_channel_close_tx: bool,
     skip_hodl_invoices: bool,
     skip_device_lock: bool,
     safe_mode: bool,
@@ -682,6 +691,7 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
             hermes_url: None,
             peer_event_callback: None,
             do_not_connect_peers: false,
+            do_not_bump_channel_close_tx: false,
             skip_device_lock: false,
             safe_mode: false,
             skip_hodl_invoices: true,
@@ -691,6 +701,7 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
     pub fn with_config(mut self, config: MutinyWalletConfig) -> MutinyWalletBuilder<S> {
         self.network = Some(config.network);
         self.do_not_connect_peers = config.do_not_connect_peers;
+        self.do_not_bump_channel_close_tx = config.do_not_bump_channel_close_tx;
         self.skip_hodl_invoices = config.skip_hodl_invoices;
         self.skip_device_lock = config.skip_device_lock;
         self.safe_mode = config.safe_mode;
@@ -727,6 +738,10 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
 
     pub fn do_not_connect_peers(&mut self) {
         self.do_not_connect_peers = true;
+    }
+
+    pub fn do_not_bump_channel_close_tx(&mut self) {
+        self.do_not_bump_channel_close_tx = true;
     }
 
     pub fn do_not_skip_hodl_invoices(&mut self) {

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -208,6 +208,7 @@ pub struct NodeBuilder<S: MutinyStorage> {
     lsp_config: Option<LspConfig>,
     logger: Option<Arc<MutinyLogger>>,
     do_not_connect_peers: bool,
+    do_not_bump_channel_close_tx: bool,
 }
 
 impl<S: MutinyStorage> NodeBuilder<S> {
@@ -231,6 +232,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             logger: None,
             network: None,
             do_not_connect_peers: false,
+            do_not_bump_channel_close_tx: false,
         }
     }
 
@@ -318,6 +320,10 @@ impl<S: MutinyStorage> NodeBuilder<S> {
 
     pub fn do_not_connect_peers(&mut self) {
         self.do_not_connect_peers = true;
+    }
+
+    pub fn do_not_bump_channel_close_tx(&mut self) {
+        self.do_not_bump_channel_close_tx = true;
     }
 
     pub fn log_params(&self, logger: &Arc<MutinyLogger>) {
@@ -590,6 +596,11 @@ impl<S: MutinyStorage> NodeBuilder<S> {
 
         // init event handler
         log_trace!(logger, "creating event handler");
+
+        if self.do_not_bump_channel_close_tx {
+            log_info!(logger, "Disable bump for channel close transaction");
+        }
+
         let event_handler = EventHandler::new(
             channel_manager.clone(),
             fee_estimator.clone(),
@@ -599,6 +610,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             bump_tx_event_handler,
             lsp_client.clone(),
             logger.clone(),
+            self.do_not_bump_channel_close_tx,
         );
         log_trace!(logger, "finished creating event handler");
 

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -431,6 +431,10 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
                     node_builder.do_not_connect_peers();
                 }
 
+                if c.do_not_bump_channel_close_tx {
+                    node_builder.do_not_bump_channel_close_tx();
+                }
+
                 let node = node_builder.build().await?;
 
                 let id = node
@@ -500,6 +504,7 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             lsp_config,
             logger,
             do_not_connect_peers: c.do_not_connect_peers,
+            do_not_bump_channel_close_tx: c.do_not_bump_channel_close_tx,
             safe_mode: c.safe_mode,
             has_done_initial_ldk_sync,
         };
@@ -535,6 +540,7 @@ pub struct NodeManager<S: MutinyStorage> {
     pub(crate) lsp_config: Option<LspConfig>,
     pub(crate) logger: Arc<MutinyLogger>,
     do_not_connect_peers: bool,
+    do_not_bump_channel_close_tx: bool,
     pub safe_mode: bool,
     /// If we've completed an initial sync this instance
     pub(crate) has_done_initial_ldk_sync: Arc<AtomicBool>,
@@ -1992,6 +1998,10 @@ pub(crate) async fn create_new_node_from_node_manager<S: MutinyStorage>(
     }
     if node_manager.do_not_connect_peers {
         node_builder.do_not_connect_peers();
+    }
+
+    if node_manager.do_not_bump_channel_close_tx {
+        node_builder.do_not_bump_channel_close_tx();
     }
 
     let new_node = node_builder.build().await?;

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -96,18 +96,13 @@ impl MutinyWallet {
         skip_device_lock: Option<bool>,
         safe_mode: Option<bool>,
         skip_hodl_invoices: Option<bool>,
-        nsec_override: Option<String>,
+        do_not_bump_channel_close_tx: Option<bool>,
         nip_07_key: Option<String>,
         blind_auth_url: Option<String>,
         hermes_url: Option<String>,
         peer_event_topic: Option<String>,
     ) -> Result<MutinyWallet, MutinyJsError> {
         let start = instant::Instant::now();
-        // if both are set throw an error
-        // todo default to nsec if both are for same key?
-        if nsec_override.is_some() && nip_07_key.is_some() {
-            return Err(MutinyJsError::InvalidArgumentsError);
-        }
 
         utils::set_panic_hook();
         let mut init = INITIALIZED.lock().await;
@@ -151,7 +146,7 @@ impl MutinyWallet {
             skip_device_lock,
             safe_mode,
             skip_hodl_invoices,
-            nsec_override,
+            do_not_bump_channel_close_tx,
             nip_07_key,
             blind_auth_url,
             hermes_url,
@@ -193,7 +188,7 @@ impl MutinyWallet {
         skip_device_lock: Option<bool>,
         safe_mode: Option<bool>,
         skip_hodl_invoices: Option<bool>,
-        _nsec_override: Option<String>,
+        do_not_bump_channel_close_tx: Option<bool>,
         _nip_07_key: Option<String>,
         blind_auth_url: Option<String>,
         hermes_url: Option<String>,
@@ -271,6 +266,9 @@ impl MutinyWallet {
         }
         if let Some(true) = do_not_connect_peers {
             config_builder.do_not_connect_peers();
+        }
+        if let Some(true) = do_not_bump_channel_close_tx {
+            config_builder.do_not_bump_channel_close_tx();
         }
         if safe_mode {
             config_builder.with_safe_mode();


### PR DESCRIPTION
Reuse an argument to support disable bump transaction for close channel tx

``` rust
-       nsec_override: Option<String>,
+       do_not_bump_channel_close_tx: Option<bool>,
```