### PR TITLE
Try to resume disconnected peer channels when inbound / outbound capacity insufficient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.8"
+version = "1.10.9"
 edition = "2021"
 authors = [
   "Tony Giorgio <tony@mutinywallet.com>",


### PR DESCRIPTION
In some special situations, the node open channels with peers other than the LSP node. These channels becomes unusable when peers disconnected.

This PR try to resume unusable channels by re-connect counter party when inbound / outbound capacity insufficient.