### PR TITLE
Expose bump transaction and channel close events

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -79,7 +79,7 @@ use lightning::{log_debug, log_error, log_info, log_trace, log_warn};
 pub use lightning_invoice;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription};
 
-use messagehandler::PeerEventCallback;
+use messagehandler::CommonLnEventCallback;
 use serde::{Deserialize, Serialize};
 use utils::{spawn_with_handle, StopHandle};
 
@@ -669,7 +669,7 @@ pub struct MutinyWalletBuilder<S: MutinyStorage> {
     network: Option<Network>,
     blind_auth_url: Option<String>,
     hermes_url: Option<String>,
-    peer_event_callback: Option<PeerEventCallback>,
+    ln_event_callback: Option<CommonLnEventCallback>,
     subscription_url: Option<String>,
     do_not_connect_peers: bool,
     do_not_bump_channel_close_tx: bool,
@@ -689,7 +689,7 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
             subscription_url: None,
             blind_auth_url: None,
             hermes_url: None,
-            peer_event_callback: None,
+            ln_event_callback: None,
             do_not_connect_peers: false,
             do_not_bump_channel_close_tx: false,
             skip_device_lock: false,
@@ -732,8 +732,8 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
         self.hermes_url = Some(hermes_url);
     }
 
-    pub fn with_peer_event_callback(&mut self, cb: PeerEventCallback) {
-        self.peer_event_callback = Some(cb);
+    pub fn with_ln_event_callback(&mut self, cb: CommonLnEventCallback) {
+        self.ln_event_callback = Some(cb);
     }
 
     pub fn do_not_connect_peers(&mut self) {
@@ -835,8 +835,8 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
             .with_config(config.clone());
         nm_builder.with_logger(logger.clone());
         nm_builder.with_esplora(esplora.clone());
-        if let Some(cb) = self.peer_event_callback.clone() {
-            nm_builder.with_peer_event_callback(cb);
+        if let Some(cb) = self.ln_event_callback.clone() {
+            nm_builder.with_ln_event_callback(cb);
         }
         let node_manager = Arc::new(nm_builder.build().await?);
 

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2,7 +2,7 @@ use crate::labels::LabelStorage;
 use crate::ldkstorage::CHANNEL_CLOSURE_PREFIX;
 use crate::logging::LOGGING_KEY;
 use crate::lsp::voltage;
-use crate::messagehandler::PeerEventCallback;
+use crate::messagehandler::CommonLnEventCallback;
 use crate::peermanager::PeerManager;
 use crate::utils::sleep;
 use crate::MutinyInvoice;
@@ -252,7 +252,7 @@ pub struct NodeManagerBuilder<S: MutinyStorage> {
     config: Option<MutinyWalletConfig>,
     stop: Option<Arc<AtomicBool>>,
     logger: Option<Arc<MutinyLogger>>,
-    peer_event_callback: Option<PeerEventCallback>,
+    ln_event_callback: Option<CommonLnEventCallback>,
 }
 
 impl<S: MutinyStorage> NodeManagerBuilder<S> {
@@ -264,7 +264,7 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             config: None,
             stop: None,
             logger: None,
-            peer_event_callback: None,
+            ln_event_callback: None,
         }
     }
 
@@ -281,8 +281,8 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
         self.esplora = Some(esplora);
     }
 
-    pub fn with_peer_event_callback(&mut self, cb: PeerEventCallback) {
-        self.peer_event_callback = Some(cb);
+    pub fn with_ln_event_callback(&mut self, cb: CommonLnEventCallback) {
+        self.ln_event_callback = Some(cb);
     }
 
     pub fn with_logger(&mut self, logger: Arc<MutinyLogger>) {
@@ -424,8 +424,8 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
                 if let Some(l) = lsp_config.clone() {
                     node_builder.with_lsp_config(l);
                 }
-                if let Some(cb) = self.peer_event_callback.clone() {
-                    node_builder.with_peer_event_callback(cb);
+                if let Some(cb) = self.ln_event_callback.clone() {
+                    node_builder.with_ln_event_callback(cb);
                 }
                 if c.do_not_connect_peers {
                     node_builder.do_not_connect_peers();
@@ -500,7 +500,7 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             websocket_proxy_addr,
             user_rgs_url: c.user_rgs_url,
             esplora,
-            peer_event_callback: self.peer_event_callback,
+            ln_event_callback: self.ln_event_callback,
             lsp_config,
             logger,
             do_not_connect_peers: c.do_not_connect_peers,
@@ -528,7 +528,7 @@ pub struct NodeManager<S: MutinyStorage> {
     websocket_proxy_addr: String,
     user_rgs_url: Option<String>,
     esplora: Arc<AsyncClient>,
-    peer_event_callback: Option<PeerEventCallback>,
+    ln_event_callback: Option<CommonLnEventCallback>,
     pub(crate) wallet: Arc<OnChainWallet<S>>,
     gossip_sync: Arc<RapidGossipSync>,
     scorer: Arc<utils::Mutex<HubPreferentialScorer>>,
@@ -1977,8 +1977,8 @@ pub(crate) async fn create_new_node_from_node_manager<S: MutinyStorage>(
     if let Some(l) = node_manager.lsp_config.clone() {
         node_builder.with_lsp_config(l);
     }
-    if let Some(cb) = node_manager.peer_event_callback.clone() {
-        node_builder.with_peer_event_callback(cb);
+    if let Some(cb) = node_manager.ln_event_callback.clone() {
+        node_builder.with_ln_event_callback(cb);
     }
     if node_manager.do_not_connect_peers {
         node_builder.do_not_connect_peers();


### PR DESCRIPTION
1. Repropose peer event broadcast  #18 , now the channel broadcasts two new events: `BumpChannelCloseTransaction` and `ChannelClosed`
2. The Js caller receives new events without any change. 
    1. `BumpChannelCloseTransaction` event hints wallet to broadcast channel close transaction through backend mempool in case the node failed to broadcast tx through P2P network.
    2. `ChannelClosed` event hint wallet a potential force closed event is occured.