### PR TITLE
[Hold]Construct tx and sweep funds with foreign utxo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.18"
+version = "1.10.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -117,6 +117,12 @@ pub enum MutinyError {
     /// A wallet operation failed.
     #[error("Failed to conduct wallet operation.")]
     WalletOperationFailed,
+    /// Add a foreign utxo failed.
+    #[error("Failed to add foreign utxo.")]
+    AddForeignUtxoFailed,
+    /// BTC PSBT hex or vout invalid
+    #[error("Invalid BTC PSBT or Vout.")]
+    InvalidBtcPsbtOrVout,
     /// A signing operation failed.
     #[error("Failed to sign given transaction.")]
     WalletSigningFailed,

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.18"
+version = "1.10.19"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -107,6 +107,12 @@ pub enum MutinyJsError {
     /// A wallet operation failed.
     #[error("Failed to conduct wallet operation.")]
     WalletOperationFailed,
+    /// Add a foreign utxo failed.
+    #[error("Failed to add foreign utxo.")]
+    AddForeignUtxoFailed,
+    /// BTC PSBT hex or vout invalid
+    #[error("Invalid BTC PSBT or Vout.")]
+    InvalidBtcPsbtOrVout,
     /// A signing operation failed.
     #[error("Failed to sign given transaction.")]
     WalletSigningFailed,
@@ -218,6 +224,8 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::LnDecodeError => MutinyJsError::LnDecodeError,
             MutinyError::SeedGenerationFailed => MutinyJsError::SeedGenerationFailed,
             MutinyError::WalletOperationFailed => MutinyJsError::WalletOperationFailed,
+            MutinyError::AddForeignUtxoFailed => MutinyJsError::AddForeignUtxoFailed,
+            MutinyError::InvalidBtcPsbtOrVout => MutinyJsError::InvalidBtcPsbtOrVout,
             MutinyError::InvalidMnemonic => MutinyJsError::InvalidMnemonic,
             MutinyError::WalletSigningFailed => MutinyJsError::WalletSigningFailed,
             MutinyError::ChainAccessFailed => MutinyJsError::ChainAccessFailed,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -472,6 +472,73 @@ impl MutinyWallet {
             .to_string())
     }
 
+    /// Sweeps all the funds from the wallet to the given address.
+    /// The fee rate is in sat/vbyte.
+    ///
+    /// If a fee rate is not provided, one will be used from the fee estimator.
+    ///
+    /// # Arguments
+    /// * `destination_address` - The address to send funds to
+    /// * `psbt_hex` - The PSBT in hex format containing the foreign UTXO
+    /// * `vout` - The output index of the foreign UTXO in the PSBT
+    /// * `fee_rate` - Optional fee rate in sats/vbyte. If None, will use default fee estimation
+    /// * `allow_dust` - Optional flag to allow dust outputs. Defaults to false
+    ///
+    /// # Returns
+    /// The transaction ID of the broadcast transaction
+    ///
+    /// # Errors
+    /// Returns `MutinyJsError` if transaction creation, signing, or broadcast fails
+    #[wasm_bindgen]
+    pub async fn sweep_wallet_with_foreign_utxo(
+        &self,
+        destination_address: String,
+        psbt_hex: String,
+        vout: u32,
+        fee_rate: Option<u64>,
+        allow_dust: Option<bool>,
+    ) -> Result<String, MutinyJsError> {
+        let send_to =
+            Address::from_str(&destination_address)?.require_network(self.inner.get_network())?;
+        Ok(self
+            .inner
+            .sweep_wallet_with_foreign_utxo(send_to, psbt_hex, vout, fee_rate, allow_dust)
+            .await?
+            .to_string())
+    }
+
+    /// Creates and extracts a sweep transaction that sends all available funds to the given address.
+    /// This transaction will be signed but not broadcast.
+    ///
+    /// # Arguments
+    /// * `destination_address` - The address to send funds to
+    /// * `psbt_hex` - The PSBT in hex format containing the foreign UTXO
+    /// * `vout` - The output index of the foreign UTXO in the PSBT
+    /// * `fee_rate` - Optional fee rate in sats/vbyte. If None, will use default fee estimation
+    /// * `allow_dust` - Optional flag to allow dust outputs. Defaults to false
+    ///
+    /// # Returns
+    /// The serialized signed transaction ready for broadcast
+    ///
+    /// # Errors
+    /// Returns `MutinyJsError` if transaction creation or signing fails
+    #[wasm_bindgen]
+    pub async fn create_and_extract_sweep_tx(
+        &self,
+        destination_address: String,
+        psbt_hex: String,
+        vout: u32,
+        fee_rate: Option<u64>,
+        allow_dust: Option<bool>,
+    ) -> Result<String, MutinyJsError> {
+        let send_to =
+            Address::from_str(&destination_address)?.require_network(self.inner.get_network())?;
+        Ok(self
+            .inner
+            .create_and_extract_sweep_tx(send_to, psbt_hex, vout, fee_rate, allow_dust)
+            .await?)
+    }
+
     /// Estimates the onchain fee for a transaction sending to the given address.
     /// The amount is in satoshis and the fee rate is in sat/vbyte.
     pub async fn estimate_tx_fee(


### PR DESCRIPTION
## Changes

- Creates and extracts a sweep transaction that sends all available funds to the given address and this transaction will be signed but not broadcast. 
  - The caller can use this function to get sweep tx and calculate tx size. 
- Sweep all the funds from the wallet to the given address using a foreign UTXO.
- @ShookLyngs Please confirm whether a single UTXO meets the requirements.

## Functions

```rust
    /// Sweeps all the funds from the wallet to the given address.
    /// The fee rate is in sat/vbyte.
    ///
    /// If a fee rate is not provided, one will be used from the fee estimator.
    ///
    /// # Arguments
    /// * `destination_address` - The address to send funds to
    /// * `psbt_hex` - The PSBT in hex format containing the foreign UTXO
    /// * `vout` - The output index of the foreign UTXO in the PSBT
    /// * `fee_rate` - Optional fee rate in sats/vbyte. If None, will use default fee estimation
    /// * `allow_dust` - Optional flag to allow dust outputs. Defaults to false
    ///
    /// # Returns
    /// The transaction ID of the broadcast transaction
    ///
    /// # Errors
    /// Returns `MutinyJsError` if transaction creation, signing, or broadcast fails
    #[wasm_bindgen]
    pub async fn sweep_wallet_with_foreign_utxo(
        &self,
        destination_address: String,
        psbt_hex: String,
        vout: u32,
        fee_rate: Option<u64>,
        allow_dust: Option<bool>,
    ) -> Result<String, MutinyJsError> {
        let send_to =
            Address::from_str(&destination_address)?.require_network(self.inner.get_network())?;
        Ok(self
            .inner
            .sweep_wallet_with_foreign_utxo(send_to, psbt_hex, vout, fee_rate, allow_dust)
            .await?
            .to_string())
    }

    /// Creates and extracts a sweep transaction that sends all available funds to the given address.
    /// This transaction will be signed but not broadcast.
    ///
    /// # Arguments
    /// * `destination_address` - The address to send funds to
    /// * `psbt_hex` - The PSBT in hex format containing the foreign UTXO
    /// * `vout` - The output index of the foreign UTXO in the PSBT
    /// * `fee_rate` - Optional fee rate in sats/vbyte. If None, will use default fee estimation
    /// * `allow_dust` - Optional flag to allow dust outputs. Defaults to false
    ///
    /// # Returns
    /// The serialized signed transaction ready for broadcast
    ///
    /// # Errors
    /// Returns `MutinyJsError` if transaction creation or signing fails
    #[wasm_bindgen]
    pub async fn create_and_extract_sweep_tx(
        &self,
        destination_address: String,
        psbt_hex: String,
        vout: u32,
        fee_rate: Option<u64>,
        allow_dust: Option<bool>,
    ) -> Result<String, MutinyJsError> {
        let send_to =
            Address::from_str(&destination_address)?.require_network(self.inner.get_network())?;
        Ok(self
            .inner
            .create_and_extract_sweep_tx(send_to, psbt_hex, vout, fee_rate, allow_dust)
            .await?)
    }
```