### PR TITLE
Construct sweep tx and insert unconfirmed tx to wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.18"
+version = "1.10.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -114,6 +114,9 @@ pub enum MutinyError {
     /// User provided invalid mnemonic.
     #[error("Invalid mnemonic")]
     InvalidMnemonic,
+    /// Invalid BTC transaction or hex string.
+    #[error("Invalid BTC transaction")]
+    InvalidTransaction,
     /// A wallet operation failed.
     #[error("Failed to conduct wallet operation.")]
     WalletOperationFailed,

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.18"
+version = "1.10.19"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -104,6 +104,9 @@ pub enum MutinyJsError {
     /// User provided invalid mnemonic.
     #[error("Invalid mnemonic")]
     InvalidMnemonic,
+    /// Invalid BTC transaction or hex string.
+    #[error("Invalid BTC transaction")]
+    InvalidTransaction,
     /// A wallet operation failed.
     #[error("Failed to conduct wallet operation.")]
     WalletOperationFailed,
@@ -219,6 +222,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::SeedGenerationFailed => MutinyJsError::SeedGenerationFailed,
             MutinyError::WalletOperationFailed => MutinyJsError::WalletOperationFailed,
             MutinyError::InvalidMnemonic => MutinyJsError::InvalidMnemonic,
+            MutinyError::InvalidTransaction => MutinyJsError::InvalidTransaction,
             MutinyError::WalletSigningFailed => MutinyJsError::WalletSigningFailed,
             MutinyError::ChainAccessFailed => MutinyJsError::ChainAccessFailed,
             MutinyError::WalletSyncError => MutinyJsError::WalletSyncError,


### PR DESCRIPTION
## Changes

- Construct sweep transaction to calculate tx size and debug
- Insert an unconfirmed tx to wallet 
- Add `allow_dust` parameter for sweeping

## Functions

```rust
    /// Constructs a sweep transaction to move all funds from the wallet to the given address.
    /// The fee rate is in sat/vbyte.
    ///
    /// If a fee rate is not provided, one will be used from the fee estimator.
    #[wasm_bindgen]
    pub async fn construct_sweep_tx(
        &self,
        destination_address: String,
        fee_rate: Option<u64>,
        allow_dust: Option<bool>,
    ) -> Result<String, MutinyJsError> {
        let send_to =
            Address::from_str(&destination_address)?.require_network(self.inner.get_network())?;
        Ok(self
            .inner
            .construct_sweep_tx(send_to, fee_rate, allow_dust)?)
    }

    /// Inserts an unconfirmed transaction into the wallet.
    /// The transaction is provided as a hexadecimal string and the last seen time is in seconds.
    #[wasm_bindgen]
    pub async fn insert_unconfirmed_tx(
        &self,
        tx_hex: String,
        last_seen: u64,
    ) -> Result<(), MutinyJsError> {
        Ok(self.inner.insert_unconfirmed_tx(tx_hex, last_seen).await?)
    }
```