### PR TITLE
Save channel closure info and bumping event to VSS

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -23,6 +23,7 @@ use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PaymentInfo {
@@ -731,6 +732,10 @@ impl<S: MutinyStorage> EventHandler<S> {
                             channel_id: format!("{channel_id}"),
                             txid,
                             hex_tx,
+                            timestamp: SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .expect("current time must be greater than epoch anchor")
+                                .as_secs(),
                         });
                     }
                 }

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -44,6 +44,7 @@ pub const CHANNEL_MANAGER_KEY: &str = "manager";
 pub const MONITORS_PREFIX_KEY: &str = "monitors/";
 const CHANNEL_OPENING_PARAMS_PREFIX: &str = "chan_open_params/";
 pub const CHANNEL_CLOSURE_PREFIX: &str = "channel_closure/";
+pub const CHANNEL_CLOSURE_BUMP_PREFIX: &str = "channel_closure_bump/";
 const FAILED_SPENDABLE_OUTPUT_DESCRIPTOR_KEY: &str = "failed_spendable_outputs";
 
 pub(crate) type PhantomChannelManager<S: MutinyStorage> = LdkChannelManager<

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -39,7 +39,9 @@ mod test_utils;
 use crate::error::MutinyError;
 pub use crate::gossip::{GOSSIP_SYNC_TIME_KEY, NETWORK_GRAPH_KEY, PROB_SCORER_KEY};
 pub use crate::keymanager::generate_seed;
-pub use crate::ldkstorage::{CHANNEL_CLOSURE_PREFIX, CHANNEL_MANAGER_KEY, MONITORS_PREFIX_KEY};
+pub use crate::ldkstorage::{
+    CHANNEL_CLOSURE_BUMP_PREFIX, CHANNEL_CLOSURE_PREFIX, CHANNEL_MANAGER_KEY, MONITORS_PREFIX_KEY,
+};
 use crate::logging::MutinyLogger;
 use crate::nodemanager::NodeManager;
 use crate::nodemanager::{ChannelClosure, MutinyBip21RawMaterials};

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -12,6 +12,14 @@ use serde::{Deserialize, Serialize};
 use crate::node::LiquidityManager;
 use crate::storage::MutinyStorage;
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BumpChannelClosureTransaction {
+    pub channel_id: String,
+    pub txid: String,
+    pub hex_tx: String,
+    pub timestamp: u64,
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum CommonLnEvent {
@@ -29,6 +37,7 @@ pub enum CommonLnEvent {
         channel_id: String,
         txid: String,
         hex_tx: String,
+        timestamp: u64,
     },
     ChannelClosed {
         channel_id: String,


### PR DESCRIPTION
Considering that VSS key requires version to determine the data status, a timestamp is added to the closure event.