### PR TITLE
Fix fetch device lock panic; fix sync key chain from VSS

### DIFF
--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.21-rc2"
+version = "1.10.21-rc3"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"


### PR DESCRIPTION
1. Fix the device lock panic issue by waiting until the key synced to VSS.
2. Fix key chain VSS syncing.
3. Bump version to 1.10.21-rc3