### PR TITLE
Support specific which indexedb database to use

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1775,7 +1775,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
         let device_id = storage.get_device_id()?;
         let logs: Option<Vec<String>> = storage.get_data(LOGGING_KEY)?;
         storage.stop().await;
-        S::clear().await?;
+        S::clear(storage.database()?).await?;
         storage.start().await?;
         storage.insert_mnemonic(m)?;
         storage.write_data(NEED_FULL_SYNC_KEY.to_string(), true, None)?;


### PR DESCRIPTION
Changes:

* Now the `database` argument are required for some wasm functions.
* The `delete_all` and `clear` will only clear data stored in the databse.
* database must start with `wallet` prefix, for example `wallet-<account-1-address>`