### PR TITLE
fix: jwt request sig format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.23"
+version = "1.10.24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.23"
+version = "1.10.24"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"


### PR DESCRIPTION
This pull request includes several changes to the `mutiny-core` and `mutiny-wasm` packages, focusing on improving the signature serialization method and adding new tests.

fix signature serialization:

* [`mutiny-core/src/authclient.rs`](diffhunk://#diff-17886a141af557f1bb4a36e7718441a5c2ec28fec28138b06ebed3402a8e5abcL114-R114): Changed the signature serialization method from `serialize_compact` to `serialize_der` to ensure DER encoding is used. 

Version update:

* [`mutiny-wasm/Cargo.toml`](diffhunk://#diff-6b5dca04f2536eeedc58017a518573ae8ad5713a72bd50f626dffc2bfc7e01f6L5-R5): Incremented the package version from `1.10.23` to `1.10.24` to reflect the changes.

Test enhancements:

* [`mutiny-core/src/authclient.rs`](diffhunk://#diff-17886a141af557f1bb4a36e7718441a5c2ec28fec28138b06ebed3402a8e5abcR346-R390): Added a new asynchronous test `test_auth_manager_sign` to verify the signature and public key generation process using the updated DER serialization method.