### PR TITLE
Call uninit in stop function to avoid AlreadyRunning error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.24"
+version = "1.10.25"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.24"
+version = "1.10.25"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -500,7 +500,11 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn stop(&mut self) -> Result<(), MutinyJsError> {
         // Ok(self.inner.node_manager.stop().await?)
-        uninit();
+
+        // uninit
+        let mut init = INITIALIZED.lock().await;
+        *init = false;
+
         Ok(self.inner.stop().await?)
     }
 

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -500,6 +500,7 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn stop(&mut self) -> Result<(), MutinyJsError> {
         // Ok(self.inner.node_manager.stop().await?)
+        uninit();
         Ok(self.inner.stop().await?)
     }
 


### PR DESCRIPTION
```rust
static INITIALIZED: once_cell::sync::Lazy<Mutex<bool>> =
    once_cell::sync::Lazy::new(|| Mutex::new(false));

#[cfg(test)]
async fn uninit() {
    let mut init = INITIALIZED.lock().await;
    *init = false;
}

impl MutinyWallet {
    pub async fn new(
    ...
    ) {
        ...
        if *init {
             return Err(MutinyJsError::AlreadyRunning);
         } else {
             *init = true;
         }
         ...
   }     
}
```