### PR TITLE
fix: handle FailedParsingVssValue when wait device lock syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.25"
+version = "1.10.26"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -176,6 +176,8 @@ pub enum MutinyError {
     /// Failed to authenticate using JWT
     #[error("Failed to authenticate using JWT.")]
     JwtAuthFailure,
+    #[error("Failed to parse VSS value from getObject response.")]
+    FailedParsingVssValue,
     #[error(transparent)]
     Other(anyhow::Error),
 }

--- a/mutiny-core/src/vss.rs
+++ b/mutiny-core/src/vss.rs
@@ -168,7 +168,7 @@ impl MutinyVssClient {
             .await
             .map_err(|e| {
                 log_error!(self.logger, "Error parsing get objects response: {e}");
-                MutinyError::Other(anyhow!("Error parsing get objects response: {e}"))
+                MutinyError::FailedParsingVssValue
             })?;
 
         result.decrypt(&self.encryption_key)

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.25"
+version = "1.10.26"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -186,6 +186,8 @@ pub enum MutinyJsError {
     InvalidHex,
     #[error("JWT Auth Failure")]
     JwtAuthFailure,
+    #[error("Failed to parse VSS value from getObject response.")]
+    FailedParsingVssValue,
     /// Unknown error.
     #[error("Unknown Error")]
     UnknownError,
@@ -252,6 +254,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::InvalidPsbt => MutinyJsError::InvalidPsbt,
             MutinyError::InvalidHex => MutinyJsError::InvalidHex,
             MutinyError::JwtAuthFailure => MutinyJsError::JwtAuthFailure,
+            MutinyError::FailedParsingVssValue => MutinyJsError::FailedParsingVssValue,
         }
     }
 }


### PR DESCRIPTION
Handle `FailedParsingVssValue` when wait device lock syncing, usually it's a failure to parse because it doesn't exist.

### Error Handling Improvements:
* Added `FailedParsingVssValue` variant to `MutinyError` and `MutinyJsError` enums to handle errors when parsing VSS values. (`mutiny-core/src/error.rs`, `mutiny-wasm/src/error.rs`) [[1]](diffhunk://#diff-dd46db67378d3ade38f27e2a842c33a3801533b647c2e3111779b826856de5a8R179-R180) [[2]](diffhunk://#diff-8097d427dba2f3bf7ac688682ca8c82852ce6142ae909e2f85d7d4e4feb6285fR189-R190)

### Device Lock Syncing Logic:
* Modified the device lock syncing logic in `MutinyWalletBuilder` to handle retries and specific error logging for VSS parsing failures. (`mutiny-core/src/lib.rs`)

### Version Update:
* Updated the version of the `mutiny-wasm` package from `1.10.25` to `1.10.26`. (`mutiny-wasm/Cargo.toml`)
