### PR TITLE
Rebroadcast commitment tx when handle Event BumpTransactionEvent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.26"
+version = "1.10.27"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.26"
+version = "1.10.27"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"


### PR DESCRIPTION
Try to resolve issue: when the following event is triggered, some nodes occasionally fail to find the target transaction in their transaction pool. If the transaction is not rebroadcast, it causes the close channel process to get stuck.

```json
{
    "type": "BumpChannelCloseTransaction",
    "channel_id": "8be434ef731fd1389058270aa5c9cc63a06a5a243e64716a633cb2db3f7f645a",
    "txid": "aef0880451ba3ce1262b64a7dc5f74cb96c3ddb83b174bccc20424993e48fe67",
    "hex_tx": "020000000001018be434ef731fd1389058270aa5c9cc63a06a5a243e64716a633cb2db3f7f645a0000000000c2108680044a010000000000002200200bdf8455e7ba4f09b1b83c04541aed300b5352cbcc5a1e6b768433bf1f7586544a01000000000000220020eaddc6a94fc57d02af8bc53d4edf3e4b922ee8329786b4fd78d45dd3a047bc1b9f49000000000000220020cd4a91bf8c3c658e598063bbe9ede4e901ce968e598313eaf25bdfba48eb02c8306e000000000000220020d31c39d0a7a29a7bff33e4957a65bd7f0e6fd14302f714a9f8d2b2b6505efdf1040047304402206d3788e5c65fc25b43be8958719fb07fd0254d3b6a3f3be52aebe219569cbb8702201fd4953bc8d90eb9a429d14668e000d319f1427988a18cb063230db7e25d5fde01483045022100f3d0f6d76d2c2a641a44066cb01f84d861d45106e37e7bf29213d4e8ea7468930220680362547e739acc85f766c990d321a3c96f25d045a2287e0de548515ea4e9cf014752210216aca236ad565c6767e63479b4f477b9e4aa7a6c98bc59adfcd6b0a011cc64062103fff60865e75bce02d127d2bf1ffa0123635f2cb9942a7f5a4cf6fd0ef18799bc52aeda0dc520",
    "timestamp": 1736836973
}
```