### PR TITLE
fix: avoid duplicate connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.10.27"
+version = "1.10.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.10.27"
+version = "1.10.28"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"


### PR DESCRIPTION
1. Save connection timestamps to pending_connections for better tracking of in-progress connections.
2. Prevent reconnecting to the same peer within 5 seconds to avoid duplicate connection error.
3. Clear pending_connections