### PR TITLE
feat: use `sweep_target_address` in spendable tx

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -101,6 +101,7 @@ pub struct EventHandler<S: MutinyStorage> {
     lsp_client: Option<AnyLsp<S>>,
     logger: Arc<MutinyLogger>,
     do_not_bump_channel_closed_tx: bool,
+    sweep_target_address: Option<bitcoin::Address>,
     ln_event_callback: Option<CommonLnEventCallback>,
 }
 
@@ -116,6 +117,7 @@ impl<S: MutinyStorage> EventHandler<S> {
         lsp_client: Option<AnyLsp<S>>,
         logger: Arc<MutinyLogger>,
         do_not_bump_channel_closed_tx: bool,
+        sweep_target_address: Option<bitcoin::Address>,
         ln_event_callback: Option<CommonLnEventCallback>,
     ) -> Self {
         Self {
@@ -128,6 +130,7 @@ impl<S: MutinyStorage> EventHandler<S> {
             bump_tx_event_handler,
             logger,
             do_not_bump_channel_closed_tx,
+            sweep_target_address,
             ln_event_callback,
         }
     }

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -873,6 +873,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                 tx_feerate,
                 locktime,
                 &Secp256k1::new(),
+                self.sweep_target_address.clone(),
             )
             .map_err(|_| anyhow!("Failed to spend spendable outputs"))?;
 

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -12,7 +12,7 @@ use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::RecoverableSignature;
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey, Signing};
-use bitcoin::{ScriptBuf, Transaction, TxOut};
+use bitcoin::{Address, ScriptBuf, Transaction, TxOut};
 use lightning::ln::msgs::{DecodeError, UnsignedGossipMessage};
 use lightning::ln::script::ShutdownScript;
 use lightning::offers::invoice::UnsignedBolt12Invoice;
@@ -68,8 +68,11 @@ impl<S: MutinyStorage> PhantomKeysManager<S> {
         feerate_sat_per_1000_weight: u32,
         locktime: Option<LockTime>,
         secp_ctx: &Secp256k1<C>,
+        sweep_target_address: Option<Address>,
     ) -> Result<Transaction, ()> {
-        let address = {
+        let address = if let Some(address) = sweep_target_address {
+            address
+        } else {
             let mut wallet = self.wallet.wallet.try_write().map_err(|_| ())?;
             // These often fail because we continually retry these. Use LastUnused so we don't generate a ton of new
             // addresses for no reason.

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -536,6 +536,7 @@ pub struct MutinyWalletConfigBuilder {
     hermes_url: Option<String>,
     do_not_connect_peers: bool,
     do_not_bump_channel_close_tx: bool,
+    sweep_target_address: Option<Address>,
     skip_device_lock: bool,
     pub safe_mode: bool,
     skip_hodl_invoices: bool,
@@ -559,6 +560,7 @@ impl MutinyWalletConfigBuilder {
             hermes_url: None,
             do_not_connect_peers: false,
             do_not_bump_channel_close_tx: false,
+            sweep_target_address: None,
             skip_device_lock: false,
             safe_mode: false,
             skip_hodl_invoices: true,
@@ -620,6 +622,10 @@ impl MutinyWalletConfigBuilder {
         self.do_not_bump_channel_close_tx = true;
     }
 
+    pub fn with_sweep_target_address(&mut self, sweep_target_address: Address) {
+        self.sweep_target_address = Some(sweep_target_address);
+    }
+
     pub fn with_skip_device_lock(&mut self) {
         self.skip_device_lock = true;
     }
@@ -652,6 +658,7 @@ impl MutinyWalletConfigBuilder {
             hermes_url: self.hermes_url,
             do_not_connect_peers: self.do_not_connect_peers,
             do_not_bump_channel_close_tx: self.do_not_bump_channel_close_tx,
+            sweep_target_address: self.sweep_target_address,
             skip_device_lock: self.skip_device_lock,
             safe_mode: self.safe_mode,
             skip_hodl_invoices: self.skip_hodl_invoices,
@@ -676,6 +683,7 @@ pub struct MutinyWalletConfig {
     hermes_url: Option<String>,
     do_not_connect_peers: bool,
     do_not_bump_channel_close_tx: bool,
+    sweep_target_address: Option<Address>,
     skip_device_lock: bool,
     pub safe_mode: bool,
     skip_hodl_invoices: bool,
@@ -694,6 +702,7 @@ pub struct MutinyWalletBuilder<S: MutinyStorage> {
     subscription_url: Option<String>,
     do_not_connect_peers: bool,
     do_not_bump_channel_close_tx: bool,
+    sweep_target_address: Option<Address>,
     skip_hodl_invoices: bool,
     skip_device_lock: bool,
     safe_mode: bool,
@@ -715,6 +724,7 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
             ln_event_callback: None,
             do_not_connect_peers: false,
             do_not_bump_channel_close_tx: false,
+            sweep_target_address: None,
             skip_device_lock: false,
             safe_mode: false,
             skip_hodl_invoices: true,
@@ -726,6 +736,7 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
         self.network = Some(config.network);
         self.do_not_connect_peers = config.do_not_connect_peers;
         self.do_not_bump_channel_close_tx = config.do_not_bump_channel_close_tx;
+        self.sweep_target_address = config.sweep_target_address.clone();
         self.skip_hodl_invoices = config.skip_hodl_invoices;
         self.skip_device_lock = config.skip_device_lock;
         self.safe_mode = config.safe_mode;
@@ -775,6 +786,10 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
 
     pub fn do_not_bump_channel_close_tx(&mut self) {
         self.do_not_bump_channel_close_tx = true;
+    }
+
+    pub fn with_sweep_target_address(&mut self, sweep_target_address: Address) {
+        self.sweep_target_address = Some(sweep_target_address);
     }
 
     pub fn do_not_skip_hodl_invoices(&mut self) {

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -435,6 +435,10 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
                     node_builder.do_not_bump_channel_close_tx();
                 }
 
+                if let Some(ref address) = c.sweep_target_address {
+                    node_builder.with_sweep_target_address(address.clone());
+                }
+
                 let node = node_builder.build().await?;
 
                 let id = node
@@ -505,6 +509,7 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             logger,
             do_not_connect_peers: c.do_not_connect_peers,
             do_not_bump_channel_close_tx: c.do_not_bump_channel_close_tx,
+            sweep_target_address: c.sweep_target_address,
             safe_mode: c.safe_mode,
             has_done_initial_ldk_sync,
         };
@@ -541,6 +546,7 @@ pub struct NodeManager<S: MutinyStorage> {
     pub(crate) logger: Arc<MutinyLogger>,
     do_not_connect_peers: bool,
     do_not_bump_channel_close_tx: bool,
+    sweep_target_address: Option<Address>,
     pub safe_mode: bool,
     /// If we've completed an initial sync this instance
     pub(crate) has_done_initial_ldk_sync: Arc<AtomicBool>,
@@ -2017,6 +2023,10 @@ pub(crate) async fn create_new_node_from_node_manager<S: MutinyStorage>(
 
     if node_manager.do_not_bump_channel_close_tx {
         node_builder.do_not_bump_channel_close_tx();
+    }
+
+    if let Some(ref address) = node_manager.sweep_target_address {
+        node_builder.with_sweep_target_address(address.clone());
     }
 
     let new_node = node_builder.build().await?;

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -101,6 +101,7 @@ impl MutinyWallet {
         safe_mode: Option<bool>,
         skip_hodl_invoices: Option<bool>,
         do_not_bump_channel_close_tx: Option<bool>,
+        sweep_target_address: Option<String>,
         nip_07_key: Option<String>,
         blind_auth_url: Option<String>,
         hermes_url: Option<String>,
@@ -153,6 +154,7 @@ impl MutinyWallet {
             safe_mode,
             skip_hodl_invoices,
             do_not_bump_channel_close_tx,
+            sweep_target_address,
             nip_07_key,
             blind_auth_url,
             hermes_url,
@@ -197,6 +199,7 @@ impl MutinyWallet {
         safe_mode: Option<bool>,
         skip_hodl_invoices: Option<bool>,
         do_not_bump_channel_close_tx: Option<bool>,
+        sweep_target_address: Option<String>,
         _nip_07_key: Option<String>,
         blind_auth_url: Option<String>,
         hermes_url: Option<String>,
@@ -349,6 +352,10 @@ impl MutinyWallet {
         }
         if let Some(true) = do_not_bump_channel_close_tx {
             config_builder.do_not_bump_channel_close_tx();
+        }
+        if let Some(ref address) = sweep_target_address {
+            let send_to = Address::from_str(address)?.require_network(network)?;
+            config_builder.with_sweep_target_address(send_to);
         }
         if safe_mode {
             config_builder.with_safe_mode();
@@ -1369,6 +1376,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1412,6 +1420,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1430,6 +1439,7 @@ mod tests {
             Some(seed.to_string()),
             None,
             Some("regtest".to_owned()),
+            None,
             None,
             None,
             None,
@@ -1499,6 +1509,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1516,6 +1527,7 @@ mod tests {
             None,
             None,
             Some("regtest".to_owned()),
+            None,
             None,
             None,
             None,
@@ -1569,6 +1581,7 @@ mod tests {
             Some(seed.to_string()),
             None,
             Some("regtest".to_owned()),
+            None,
             None,
             None,
             None,
@@ -1643,6 +1656,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1685,6 +1699,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await;
 
@@ -1708,6 +1723,7 @@ mod tests {
             None,
             None,
             Some("regtest".to_owned()),
+            None,
             None,
             None,
             None,
@@ -1799,6 +1815,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1843,6 +1860,7 @@ mod tests {
             None,
             None,
             Some("regtest".to_owned()),
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
Passed to the mutiny lib using `sweep_target_address`, the mutiny node's background thread is automatically transferred to the target address when the channel is closed and some of the outputs satisfy the condition triggering the `Event::SpendableOutputs` event.

This eliminates the need to manually initiate a sweep tx and saves transaction fees.

For the caller, `sweep_target_address` in the `MutinyWallet:: new` parameter is similar to `destination_address` in `MutinyWallet:: sweep_wallet`, except for the additional `Option` wrapping. If `None` is passed, the behavior is the same as before.