### PR TITLE
check user provided url when call `get_rgs_url`

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1116,7 +1116,10 @@ impl<S: MutinyStorage> NodeManager<S> {
                 self.network,
                 self.user_rgs_url.as_deref(),
                 last_rgs_sync_timestamp,
-            ) {
+                self.logger.clone(),
+            )
+            .await
+            {
                 log_info!(self.logger, "RGS URL: {rgs_url}");
 
                 let now = utils::now().as_secs();


### PR DESCRIPTION
Check the [rapid-gossip-sync-server](https://github.com/lightningdevkit/rapid-gossip-sync-server) url passed in by the user, prioritize it, and switch to the official ldk service if there is a problem.

For the caller, `MutinyWallet::new` passes in the `user_rgs_url` parameter.

- self host's rgs server is ready:
  - Network::Bitcoin：keep`·None` util ready 
  - Network::Testnet："https://rapid-gossip.internal.joyid.dev/testnet/snapshot/"