### PR TITLE
Add `force_close_spend_delay` filed for `ChannelClosure`

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -688,6 +688,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                 channel_id,
                 user_channel_id,
                 counterparty_node_id,
+                funding_txo,
                 ..
             } => {
                 log_debug!(
@@ -701,6 +702,31 @@ impl<S: MutinyStorage> EventHandler<S> {
                     log_warn!(
                         self.logger,
                         "ERROR: Could not delete channel open params, but continuing: {e}"
+                    );
+                }
+
+                let all_channels = self.channel_manager.list_channels();
+                let found_channel = all_channels.iter().find(|chan| {
+                    chan.funding_txo.map(|a| a.into_bitcoin_outpoint()) == Some(funding_txo)
+                });
+                if let Some(channel) = found_channel {
+                    let closure = ChannelClosure::new_placeholder(
+                        user_channel_id,
+                        channel_id,
+                        funding_txo,
+                        counterparty_node_id,
+                        channel.force_close_spend_delay,
+                    );
+                    if let Err(e) = self
+                        .persister
+                        .persist_channel_closure(user_channel_id, closure)
+                    {
+                        log_error!(self.logger, "Failed to persist channel closure: {e}");
+                    }
+                } else {
+                    log_warn!(
+                        self.logger,
+                        "WARNING: Could not find channel with funding txo {funding_txo:?} when calling list_channels in ChannelPending event"
                     );
                 }
             }

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -402,8 +402,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
         let force_close_spend_delay = self
             .storage
             .get_channel_closure(&key)?
-            .map(|c| c.force_close_spend_delay)
-            .flatten();
+            .and_then(|c| c.force_close_spend_delay);
         let mut closure = closure;
         closure.set_force_close_spend_delay(force_close_spend_delay);
 
@@ -882,6 +881,7 @@ mod test {
             reason: "This is a test.".to_string(),
             timestamp: utils::now().as_secs(),
             channel_funding_txo: None,
+            force_close_spend_delay: None,
         };
         let result = persister.persist_channel_closure(user_channel_id, closure.clone());
         assert!(result.is_ok());

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -398,6 +398,15 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
             "{CHANNEL_CLOSURE_PREFIX}{}",
             user_channel_id.to_be_bytes().to_lower_hex_string()
         ));
+
+        let force_close_spend_delay = self
+            .storage
+            .get_channel_closure(&key)?
+            .map(|c| c.force_close_spend_delay)
+            .flatten();
+        let mut closure = closure;
+        closure.set_force_close_spend_delay(force_close_spend_delay);
+
         self.storage
             .write_data(key.clone(), &closure, Some(closure.timestamp as u32))?;
 

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2335,6 +2335,7 @@ mod tests {
             reason: "".to_string(),
             timestamp: 1686258926,
             channel_funding_txo: None,
+            force_close_spend_delay: None,
         };
         let closure_chan_id: u128 = 6969;
         node.persister

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2423,6 +2423,7 @@ mod tests {
             reason: "".to_string(),
             timestamp: 1686258926,
             channel_funding_txo: None,
+            force_close_spend_delay: None,
         };
 
         let tx1: TransactionDetails = TransactionDetails {

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -142,6 +142,7 @@ pub struct MutinyChannel {
     pub is_outbound: bool,
     pub is_usable: bool,
     pub is_anchor: bool,
+    pub force_close_spend_delay: Option<u16>,
 }
 
 impl From<&ChannelDetails> for MutinyChannel {
@@ -173,6 +174,7 @@ impl From<&ChannelDetails> for MutinyChannel {
             is_outbound: c.is_outbound,
             is_usable: c.is_usable,
             is_anchor,
+            force_close_spend_delay: c.force_close_spend_delay,
         }
     }
 }
@@ -224,7 +226,7 @@ impl ChannelClosure {
             channel_funding_txo: Some(channel_funding_txo),
             node_id: Some(node_id),
             reason: "".to_string(),
-            timestamp: 0,
+            timestamp: 0, // Ensure that the real timestamp is used to update vss when the channel is shut down
             force_close_spend_delay,
         }
     }

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -187,6 +187,7 @@ pub struct ChannelClosure {
     pub timestamp: u64,
     #[serde(default)]
     pub channel_funding_txo: Option<OutPoint>,
+    pub force_close_spend_delay: Option<u16>,
 }
 
 impl ChannelClosure {
@@ -206,6 +207,25 @@ impl ChannelClosure {
             node_id,
             reason: reason.to_string(),
             timestamp: utils::now().as_secs(),
+            force_close_spend_delay: None,
+        }
+    }
+
+    pub fn new_placeholder(
+        user_channel_id: u128,
+        channel_id: ChannelId,
+        channel_funding_txo: OutPoint,
+        node_id: PublicKey,
+        force_close_spend_delay: Option<u16>,
+    ) -> Self {
+        Self {
+            user_channel_id: Some(user_channel_id.to_be_bytes()),
+            channel_id: Some(channel_id.0),
+            channel_funding_txo: Some(channel_funding_txo),
+            node_id: Some(node_id),
+            reason: "".to_string(),
+            timestamp: 0,
+            force_close_spend_delay,
         }
     }
 
@@ -223,6 +243,14 @@ impl ChannelClosure {
         self.user_channel_id = Some(user_channel_id);
 
         Ok(())
+    }
+
+    pub fn set_force_close_spend_delay(&mut self, delay: Option<u16>) {
+        if self.force_close_spend_delay.is_some() {
+            return;
+        }
+
+        self.force_close_spend_delay = delay;
     }
 }
 

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -970,7 +970,7 @@ impl MutinyWallet {
             .list_channel_closures()
             .await?
             .into_iter()
-            .filter(|closure| closure.timestamp != 0)
+            .filter(|closure| closure.timestamp != 0) // filter out placeholder closures
             .map(Into::into)
             .collect();
         channel_closures.sort();

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -970,6 +970,7 @@ impl MutinyWallet {
             .list_channel_closures()
             .await?
             .into_iter()
+            .filter(|closure| closure.timestamp != 0)
             .map(Into::into)
             .collect();
         channel_closures.sort();

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -295,6 +295,7 @@ pub struct MutinyChannel {
     pub is_outbound: bool,
     pub is_usable: bool,
     pub is_anchor: bool,
+    pub force_close_spend_delay: Option<u16>,
 }
 
 #[wasm_bindgen]
@@ -326,6 +327,11 @@ impl MutinyChannel {
             None => false,
         }
     }
+
+    #[wasm_bindgen(getter)]
+    pub fn force_close_spend_delay(&self) -> Option<u16> {
+        self.force_close_spend_delay
+    }
 }
 
 impl From<nodemanager::MutinyChannel> for MutinyChannel {
@@ -343,6 +349,7 @@ impl From<nodemanager::MutinyChannel> for MutinyChannel {
             is_outbound: m.is_outbound,
             is_usable: m.is_usable,
             is_anchor: m.is_anchor,
+            force_close_spend_delay: m.force_close_spend_delay,
         }
     }
 }
@@ -364,6 +371,7 @@ impl From<MutinyChannel> for nodemanager::MutinyChannel {
             is_outbound: m.is_outbound,
             is_usable: m.is_usable,
             is_anchor: m.is_anchor,
+            force_close_spend_delay: m.force_close_spend_delay,
         }
     }
 }

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -377,6 +377,7 @@ pub struct ChannelClosure {
     reason: String,
     pub timestamp: u64,
     channel_funding_txo: Option<String>,
+    force_close_spend_delay: Option<u16>,
 }
 
 #[wasm_bindgen]
@@ -404,6 +405,11 @@ impl ChannelClosure {
     #[wasm_bindgen(getter)]
     pub fn channel_funding_txo(&self) -> Option<String> {
         self.channel_funding_txo.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn force_close_spend_delay(&self) -> Option<u16> {
+        self.force_close_spend_delay
     }
 }
 
@@ -440,6 +446,7 @@ impl From<nodemanager::ChannelClosure> for ChannelClosure {
             reason: c.reason,
             timestamp: c.timestamp,
             channel_funding_txo: c.channel_funding_txo.map(|txo| format!("{}", txo)),
+            force_close_spend_delay: c.force_close_spend_delay,
         }
     }
 }

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -327,11 +327,6 @@ impl MutinyChannel {
             None => false,
         }
     }
-
-    #[wasm_bindgen(getter)]
-    pub fn force_close_spend_delay(&self) -> Option<u16> {
-        self.force_close_spend_delay
-    }
 }
 
 impl From<nodemanager::MutinyChannel> for MutinyChannel {


### PR DESCRIPTION
- Add `force_close_spend_delay` filed for `ChannelClosure`,  a call to the `list_channel_closures` method will reflect this
- Add `force_close_spend_delay` filed for `MutinyChannel`, a call to the `list_channels` method will reflect this

`force_close_spend_delay` is set to `None` for older versions of the data.

```rust
/// Information about a channel that was closed.
#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
#[wasm_bindgen]
pub struct ChannelClosure {
    channel_id: Option<String>,
    node_id: Option<String>,
    reason: String,
    pub timestamp: u64,
    channel_funding_txo: Option<String>,
    force_close_spend_delay: Option<u16>,
}
```

```rust
#[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
#[wasm_bindgen]
pub struct MutinyChannel {
    user_chan_id: String,
    pub balance: u64,
    pub size: u64,
    pub reserve: u64,
    pub inbound: u64,
    outpoint: Option<String>,
    peer: String,
    pub confirmations_required: Option<u32>,
    pub confirmations: u32,
    pub is_outbound: bool,
    pub is_usable: bool,
    pub is_anchor: bool,
    pub force_close_spend_delay: Option<u16>,
}
```

The definition of [`force_close_spend_delay`](https://github.com/utxostack/rust-lightning/blob/fix-channel-manager-wasm32/lightning/src/ln/channel_state.rs#L431) is as follows:

```rust
	/// The number of blocks (after our commitment transaction confirms) that we will need to wait
	/// until we can claim our funds after we force-close the channel. During this time our
	/// counterparty is allowed to punish us if we broadcasted a stale state. If our counterparty
	/// force-closes the channel and broadcasts a commitment transaction we do not have to wait any
	/// time to claim our non-HTLC-encumbered funds.
	///
	/// This value will be `None` for outbound channels until the counterparty accepts the channel.
	pub force_close_spend_delay: Option<u16>,
```