### PR TITLE
Stop reading socket once descriptor is closed

### DIFF
--- a/mutiny-core/src/peermanager.rs
+++ b/mutiny-core/src/peermanager.rs
@@ -522,7 +522,7 @@ async fn connect_peer<P: PeerManager>(
             .await?;
             let (_, net_addr) = try_parse_addr_string(t);
             (
-                AnySocketDescriptor::Tcp(WsTcpSocketDescriptor::new(Arc::new(proxy))),
+                AnySocketDescriptor::Tcp(WsTcpSocketDescriptor::new(proxy)),
                 net_addr,
             )
         }


### PR DESCRIPTION
https://github.com/utxostack/rust-lightning/blob/bdbfd070a10f46653c396788ffc49e6cb6ebb00f/lightning/src/ln/peer_handler.rs#L1574

`read_event` may return an error to indicate disconnect socket. But in the current implementation, we ignored this behavior and continue to read the 'closed' descriptor. to fix it, we simply stop reading a closed descriptor.