### PR TITLE
feat: raise event WalletFirstSynced and TxBroadcasted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -53,7 +53,7 @@ jobs:
         with:
           version: 'v0.12.1'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -94,7 +94,7 @@ jobs:
         with:
           version: 'latest'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -130,7 +130,7 @@ jobs:
         with:
           version: 'latest'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -168,7 +168,7 @@ jobs:
           profile: minimal
           components: clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -216,7 +216,7 @@ jobs:
           profile: minimal
           components: clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -263,7 +263,7 @@ jobs:
           profile: minimal
           components: clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.11.3"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -344,7 +344,17 @@ mod tests {
         let xpriv = Xpriv::new_master(network, &mnemonic.to_seed("")).unwrap();
 
         let wallet = Arc::new(
-            OnChainWallet::new(xpriv, db, network, esplora, fees, stop, logger.clone()).unwrap(),
+            OnChainWallet::new(
+                xpriv,
+                db,
+                network,
+                esplora,
+                fees,
+                stop,
+                logger.clone(),
+                None,
+            )
+            .unwrap(),
         );
 
         let km = create_keys_manager(wallet.clone(), xpriv, 1, logger.clone()).unwrap();
@@ -392,7 +402,17 @@ mod tests {
         let xpriv = Xpriv::new_master(network, &mnemonic.to_seed("")).unwrap();
 
         let wallet = Arc::new(
-            OnChainWallet::new(xpriv, db, network, esplora, fees, stop, logger.clone()).unwrap(),
+            OnChainWallet::new(
+                xpriv,
+                db,
+                network,
+                esplora,
+                fees,
+                stop,
+                logger.clone(),
+                None,
+            )
+            .unwrap(),
         );
 
         let km = create_keys_manager(wallet.clone(), xpriv, 1, logger.clone()).unwrap();

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -719,7 +719,7 @@ impl<S: MutinyStorage> Persist<InMemorySigner> for MutinyNodePersister<S> {
 
         log_debug!(
             self.logger,
-            "update_persisted_channel: (channel_id, latest_update_id, version,is_fully_resolved, claimable_balances, current_best_block): {:?}",
+            "update_persisted_channel: (channel_id, latest_update_id, version, is_fully_resolved, claimable_balances, current_best_block): {:?}",
             (
                 monitor.channel_id(),
                 monitor.get_latest_update_id(),

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -1009,6 +1009,7 @@ mod test {
                 fees.clone(),
                 stop,
                 logger.clone(),
+                None,
             )
             .unwrap(),
         );

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -679,6 +679,19 @@ impl<S: MutinyStorage> Persist<InMemorySigner> for MutinyNodePersister<S> {
             update_id,
         };
 
+        log_debug!(
+            self.logger,
+            "persist_new_channel: (channel_id, latest_update_id, version, is_fully_resolved, claimable_balances, current_best_block): {:?}",
+            (
+                monitor.channel_id().to_string(),
+                monitor.get_latest_update_id(),
+                version,
+                monitor.is_fully_resolved(self.logger.as_ref()),
+                monitor.get_claimable_balances(),
+                monitor.current_best_block(),
+            )
+        );
+
         self.init_persist_monitor(key, monitor, version, update_id)
     }
 
@@ -703,6 +716,19 @@ impl<S: MutinyStorage> Persist<InMemorySigner> for MutinyNodePersister<S> {
             funding_txo,
             update_id,
         };
+
+        log_debug!(
+            self.logger,
+            "update_persisted_channel: (channel_id, latest_update_id, version,is_fully_resolved, claimable_balances, current_best_block): {:?}",
+            (
+                monitor.channel_id(),
+                monitor.get_latest_update_id(),
+                version,
+                monitor.is_fully_resolved(self.logger.as_ref()),
+                monitor.get_claimable_balances(),
+                monitor.current_best_block()
+            )
+        );
 
         self.init_persist_monitor(key, monitor, version, update_id)
     }

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -65,6 +65,8 @@ pub enum CommonLnEvent {
         payment_hash: String,
         amount_msat: u64,
     },
+    // Wallet first synced
+    WalletFirstSynced,
 }
 
 #[derive(Clone)]

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -67,6 +67,11 @@ pub enum CommonLnEvent {
     },
     // Wallet first synced
     WalletFirstSynced,
+    // Transaction broadcasted
+    TxBroadcasted {
+        txid: String,
+        hex_tx: String,
+    },
 }
 
 #[derive(Clone)]

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2,7 +2,7 @@ use crate::labels::LabelStorage;
 use crate::ldkstorage::CHANNEL_CLOSURE_PREFIX;
 use crate::logging::LOGGING_KEY;
 use crate::lsp::voltage;
-use crate::messagehandler::CommonLnEventCallback;
+use crate::messagehandler::{CommonLnEvent, CommonLnEventCallback};
 use crate::peermanager::PeerManager;
 use crate::utils::sleep;
 use crate::MutinyInvoice;
@@ -679,6 +679,11 @@ impl<S: MutinyStorage> NodeManager<S> {
                     // if this is the first sync, set the done_first_sync flag
                     let _ = nm.storage.set_done_first_sync();
                     synced = true;
+
+                    if let Some(cb) = nm.ln_event_callback.as_ref() {
+                        let event = CommonLnEvent::WalletFirstSynced {};
+                        cb.trigger(event);
+                    }
                 }
 
                 // wait for next sync round, checking graceful shutdown check each second.

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -369,6 +369,7 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             fee_estimator.clone(),
             stop.clone(),
             logger.clone(),
+            self.ln_event_callback.clone(),
         )?);
         log_trace!(logger, "finished creating on chain wallet");
 

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -683,6 +683,7 @@ impl<S: MutinyStorage> NodeManager<S> {
                     if let Some(cb) = nm.ln_event_callback.as_ref() {
                         let event = CommonLnEvent::WalletFirstSynced {};
                         cb.trigger(event);
+                        log_debug!(nm.logger, "Triggered WalletFirstSynced event");
                     }
                 }
 

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -926,7 +926,17 @@ mod tests {
         let stop = Arc::new(AtomicBool::new(false));
         let xpriv = Xpriv::new_master(Network::Testnet, &mnemonic.to_seed("")).unwrap();
 
-        OnChainWallet::new(xpriv, db, Network::Testnet, esplora, fees, stop, logger).unwrap()
+        OnChainWallet::new(
+            xpriv,
+            db,
+            Network::Testnet,
+            esplora,
+            fees,
+            stop,
+            logger,
+            None,
+        )
+        .unwrap()
     }
 
     #[test]

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -148,7 +148,7 @@ impl<S: MutinyStorage> OnChainWallet<S> {
 
         if let Some(cb) = self.ln_event_callback.as_ref() {
             let event = CommonLnEvent::TxBroadcasted {
-                txid: format!("{:x}", tx.compute_txid()),
+                txid: format!("{:x}", txid),
                 hex_tx: bitcoin::consensus::encode::serialize_hex(&tx),
             };
             cb.trigger(event);

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -92,6 +92,7 @@ pub(crate) async fn create_node<S: MutinyStorage>(storage: S) -> Node<S> {
             fee_estimator.clone(),
             stop.clone(),
             logger.clone(),
+            None,
         )
         .unwrap(),
     );

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.11.3"
+version = "1.12.0"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.11.2"
+version = "1.11.3"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"


### PR DESCRIPTION
### New Event Types:

* Introduced `WalletFirstSynced` and `TxBroadcasted` event types to the `CommonLnEvent` enum for frontend. (`mutiny-core/src/messagehandler.rs`)

For `WalletFirstSynced`, it is advisable to retrieve the balance only after this event, as it will reflect the final accurate state. Additionally, it is recommended to establish peer connections only after the synced event has occurred.
