### PR TITLE
[BREAKINGCHANGE] Save `TryBroadcastTx1InMultiOut` event

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -47,6 +47,7 @@ const CHANNEL_OPENING_PARAMS_PREFIX: &str = "chan_open_params/";
 pub const CHANNEL_CLOSURE_PREFIX: &str = "channel_closure/";
 pub const CHANNEL_CLOSURE_BUMP_PREFIX: &str = "channel_closure_bump/";
 const FAILED_SPENDABLE_OUTPUT_DESCRIPTOR_KEY: &str = "failed_spendable_outputs";
+pub const BROADCAST_TX_1_IN_MULTI_OUT: &str = "broadcast_tx_1_in_multi_out/";
 
 pub(crate) type PhantomChannelManager<S: MutinyStorage> = LdkChannelManager<
     Arc<ChainMonitor<S>>,

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -721,7 +721,7 @@ impl<S: MutinyStorage> Persist<InMemorySigner> for MutinyNodePersister<S> {
             self.logger,
             "update_persisted_channel: (channel_id, latest_update_id, version, is_fully_resolved, claimable_balances, current_best_block): {:?}",
             (
-                monitor.channel_id(),
+                monitor.channel_id().to_string(),
                 monitor.get_latest_update_id(),
                 version,
                 monitor.is_fully_resolved(self.logger.as_ref()),

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -43,10 +43,12 @@ use crate::error::MutinyError;
 pub use crate::gossip::{GOSSIP_SYNC_TIME_KEY, NETWORK_GRAPH_KEY, PROB_SCORER_KEY};
 pub use crate::keymanager::generate_seed;
 pub use crate::ldkstorage::{
-    CHANNEL_CLOSURE_BUMP_PREFIX, CHANNEL_CLOSURE_PREFIX, CHANNEL_MANAGER_KEY, MONITORS_PREFIX_KEY,
+    BROADCAST_TX_1_IN_MULTI_OUT, CHANNEL_CLOSURE_BUMP_PREFIX, CHANNEL_CLOSURE_PREFIX,
+    CHANNEL_MANAGER_KEY, MONITORS_PREFIX_KEY,
 };
 use crate::nodemanager::NodeManager;
 use crate::nodemanager::{ChannelClosure, MutinyBip21RawMaterials};
+pub use crate::onchain::BroadcastTx1InMultiOut;
 use crate::storage::get_invoice_by_hash;
 use crate::utils::sleep;
 use crate::utils::spawn;

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -67,8 +67,8 @@ pub enum CommonLnEvent {
     },
     // Wallet first synced
     WalletFirstSynced,
-    // Try broadcast tx
-    TryBroadcastTx {
+    // Try broadcast tx 1 in multi out
+    TryBroadcastTx1InMultiOut {
         txid: String,
         hex_tx: String,
         timestamp: u64,

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -67,10 +67,11 @@ pub enum CommonLnEvent {
     },
     // Wallet first synced
     WalletFirstSynced,
-    // Transaction broadcasted
-    TxBroadcasted {
+    // Try broadcast tx
+    TryBroadcastTx {
         txid: String,
         hex_tx: String,
+        timestamp: u64,
     },
 }
 

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -24,10 +24,12 @@ use hex_conservative::DisplayHex;
 use lightning::events::bump_transaction::{Utxo, WalletSource};
 use lightning::util::logger::Logger;
 use lightning::{log_debug, log_error, log_info, log_trace, log_warn};
+use serde::{Deserialize, Serialize};
 
 use crate::error::MutinyError;
 use crate::fees::MutinyFeeEstimator;
 use crate::labels::*;
+use crate::ldkstorage::BROADCAST_TX_1_IN_MULTI_OUT;
 use crate::logging::MutinyLogger;
 use crate::messagehandler::{CommonLnEvent, CommonLnEventCallback};
 use crate::storage::{
@@ -51,6 +53,23 @@ pub struct OnChainWallet<S: MutinyStorage> {
     pub(crate) stop: Arc<AtomicBool>,
     logger: Arc<MutinyLogger>,
     ln_event_callback: Option<CommonLnEventCallback>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BroadcastTx1InMultiOut {
+    pub txid: String,
+    pub hex_tx: String,
+    pub timestamp: u64,
+}
+
+impl From<BroadcastTx1InMultiOut> for CommonLnEvent {
+    fn from(event: BroadcastTx1InMultiOut) -> Self {
+        CommonLnEvent::TryBroadcastTx1InMultiOut {
+            txid: event.txid,
+            hex_tx: event.hex_tx,
+            timestamp: event.timestamp,
+        }
+    }
 }
 
 impl<S: MutinyStorage> OnChainWallet<S> {
@@ -124,19 +143,33 @@ impl<S: MutinyStorage> OnChainWallet<S> {
         })
     }
 
+    pub(crate) fn persist_broadcast_tx_1_in_multi_out(
+        &self,
+        input: OutPoint,
+        tx: BroadcastTx1InMultiOut,
+    ) -> Result<(), MutinyError> {
+        let key = format!("{BROADCAST_TX_1_IN_MULTI_OUT}{}", input);
+        self.storage
+            .write_data(key, tx.clone(), Some(tx.timestamp as u32))?;
+        Ok(())
+    }
+
     pub async fn broadcast_transaction(&self, tx: Transaction) -> Result<(), MutinyError> {
         let txid = tx.compute_txid();
         log_info!(self.logger, "Broadcasting transaction: {txid}");
         log_debug!(self.logger, "Transaction: {}", serialize(&tx).as_hex());
 
-        if let Some(cb) = self.ln_event_callback.as_ref() {
-            let event = CommonLnEvent::TryBroadcastTx {
+        if is_tx_1_in_multi_out(&tx) {
+            let broadcast_tx = BroadcastTx1InMultiOut {
                 txid: format!("{:x}", txid),
                 hex_tx: bitcoin::consensus::encode::serialize_hex(&tx),
                 timestamp: utils::now().as_secs(),
             };
-            cb.trigger(event);
-            log_debug!(self.logger, "Triggered TxBroadcasted event");
+            if let Some(cb) = self.ln_event_callback.as_ref() {
+                cb.trigger(broadcast_tx.clone().into());
+                log_debug!(self.logger, "Triggered TryBroadcastTx1InMultiOut event");
+            }
+            self.persist_broadcast_tx_1_in_multi_out(tx.input[0].previous_output, broadcast_tx)?;
         }
 
         if let Err(e) = self.blockchain.broadcast(&tx).await {
@@ -895,6 +928,12 @@ impl<S: MutinyStorage> WalletSource for OnChainWallet<S> {
         psbt.extract_tx()
             .map_err(|e| log_error!(self.logger, "Extract signed transaction: {e:?}"))
     }
+}
+
+fn is_tx_1_in_multi_out(tx: &Transaction) -> bool {
+    let has_one_input = tx.input.len() == 1;
+    let has_multiple_outputs = tx.output.len() > 1;
+    has_one_input && has_multiple_outputs
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- `TxBroadcasted` -> `TryBroadcastTx1InMultiOut`
- save `TryBroadcastTx1InMultiOut` in vss

```rust
    // Try broadcast tx 1 in multi out
    TryBroadcastTx1InMultiOut {
        txid: String,
        hex_tx: String,
        timestamp: u64,
    },
```

Note that the same tx may be broadcast multiple times, so `TryBroadcastTx1InMultiOut` may be triggered multiple times, and for the same tx, the `timestamp` saved to db +vss is updated.
 
- [x] to be test