### PR TITLE
feat: emit vss write event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.12.2"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -333,8 +333,8 @@ mod tests {
         let network = Network::Testnet;
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let logger = Arc::new(MutinyLogger::default());
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None, logger.clone());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),
             esplora.clone(),
@@ -391,8 +391,8 @@ mod tests {
         let network = Network::Testnet;
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let logger = Arc::new(MutinyLogger::default());
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None, logger.clone());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),
             esplora.clone(),

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -333,7 +333,7 @@ mod tests {
         let network = Network::Testnet;
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),
@@ -391,7 +391,7 @@ mod tests {
         let network = Network::Testnet;
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2063,6 +2063,7 @@ struct BitcoinPriceResponse {
 #[cfg(test)]
 #[cfg(target_arch = "wasm32")]
 mod tests {
+    use crate::logging::MutinyLogger;
     use crate::storage::{
         payment_key, persist_payment_info, IndexItem, MemoryStorage, MutinyStorage, ONCHAIN_PREFIX,
         PAYMENT_OUTBOUND_PREFIX_KEY,
@@ -2088,6 +2089,7 @@ mod tests {
     use hex_conservative::DisplayHex;
     use itertools::Itertools;
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use crate::test_utils::*;
 
@@ -2107,7 +2109,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            Arc::new(MutinyLogger::default()),
+        );
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
             .with_network(network)
@@ -2130,7 +2138,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            Arc::new(MutinyLogger::default()),
+        );
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
             .with_network(network)
@@ -2158,7 +2172,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            Arc::new(MutinyLogger::default()),
+        );
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
@@ -2223,7 +2243,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            Arc::new(MutinyLogger::default()),
+        );
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
             .with_network(network)
@@ -2239,7 +2265,13 @@ mod tests {
         // create a second mw and make sure it has a different seed
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage2 = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage2 = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            Arc::new(MutinyLogger::default()),
+        );
         assert!(!NodeManager::has_node_manager(storage2.clone()));
         let xpriv2 = Xpriv::new_master(network, &[0; 32]).unwrap();
         let config2 = MutinyWalletConfigBuilder::new(xpriv2)
@@ -2259,7 +2291,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage3 = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage3 = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            Arc::new(MutinyLogger::default()),
+        );
 
         MutinyWallet::restore_mnemonic(storage3.clone(), mnemonic.clone())
             .await
@@ -2290,7 +2328,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            Arc::new(MutinyLogger::default()),
+        );
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let mut config_builder = MutinyWalletConfigBuilder::new(xpriv).with_network(network);
         config_builder.with_safe_mode();
@@ -2315,7 +2359,7 @@ mod tests {
         let test_name = "test_sort_index_item";
         log!("{}", test_name);
 
-        let storage = MemoryStorage::new(None, None, None, None);
+        let storage = MemoryStorage::new(None, None, None, None, Arc::new(MutinyLogger::default()));
         let seed = generate_seed(12).expect("Failed to gen seed");
         let network = Network::Regtest;
         let xpriv = Xpriv::new_master(network, &seed.to_seed("")).unwrap();

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2107,7 +2107,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
             .with_network(network)
@@ -2130,7 +2130,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
             .with_network(network)
@@ -2158,7 +2158,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
@@ -2223,7 +2223,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfigBuilder::new(xpriv)
             .with_network(network)
@@ -2239,7 +2239,7 @@ mod tests {
         // create a second mw and make sure it has a different seed
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage2 = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage2 = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         assert!(!NodeManager::has_node_manager(storage2.clone()));
         let xpriv2 = Xpriv::new_master(network, &[0; 32]).unwrap();
         let config2 = MutinyWalletConfigBuilder::new(xpriv2)
@@ -2259,7 +2259,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage3 = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage3 = MemoryStorage::new(Some(pass), Some(cipher), None, None);
 
         MutinyWallet::restore_mnemonic(storage3.clone(), mnemonic.clone())
             .await
@@ -2290,7 +2290,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let mut config_builder = MutinyWalletConfigBuilder::new(xpriv).with_network(network);
         config_builder.with_safe_mode();
@@ -2315,7 +2315,7 @@ mod tests {
         let test_name = "test_sort_index_item";
         log!("{}", test_name);
 
-        let storage = MemoryStorage::new(None, None, None);
+        let storage = MemoryStorage::new(None, None, None, None);
         let seed = generate_seed(12).expect("Failed to gen seed");
         let network = Network::Regtest;
         let xpriv = Xpriv::new_master(network, &seed.to_seed("")).unwrap();

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -74,7 +74,7 @@ pub enum CommonLnEvent {
         timestamp: u64,
     },
     // Before sync to VSS
-    BeforeSyncToVss {
+    SyncToVssStarting {
         key: String,
         version: Option<u32>,
         timestamp: u64,

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -73,6 +73,19 @@ pub enum CommonLnEvent {
         hex_tx: String,
         timestamp: u64,
     },
+    // Before sync to VSS
+    BeforeSyncToVss {
+        key: String,
+        version: Option<u32>,
+        timestamp: u64,
+    },
+    // Sync to VSS completed
+    SyncToVssCompleted {
+        key: String,
+        version: Option<u32>,
+        timestamp: u64,
+        duration_ms: u128,
+    },
 }
 
 #[derive(Clone)]

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2123,7 +2123,7 @@ mod tests {
     use crate::{
         encrypt::encryption_key_from_pass,
         nodemanager::{ChannelClosure, MutinyInvoice, NodeManager, TransactionDetails},
-        ActivityItem, MutinyWalletConfigBuilder, PrivacyLevel,
+        ActivityItem, MutinyLogger, MutinyWalletConfigBuilder, PrivacyLevel,
     };
     use crate::{keymanager::generate_seed, nodemanager::NodeManagerBuilder};
     use bdk_chain::ConfirmationTime;
@@ -2160,7 +2160,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            std::sync::Arc::new(MutinyLogger::default()),
+        );
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let c = MutinyWalletConfigBuilder::new(xpriv)
@@ -2182,7 +2188,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            std::sync::Arc::new(MutinyLogger::default()),
+        );
         let seed = generate_seed(12).expect("Failed to gen seed");
         let network = Network::Regtest;
         let xpriv = Xpriv::new_master(network, &seed.to_seed("")).unwrap();
@@ -2226,7 +2238,13 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
+        let storage = MemoryStorage::new(
+            Some(pass),
+            Some(cipher),
+            None,
+            None,
+            std::sync::Arc::new(MutinyLogger::default()),
+        );
         let seed = generate_seed(12).expect("Failed to gen seed");
         let network = Network::Regtest;
         let xpriv = Xpriv::new_master(network, &seed.to_seed("")).unwrap();

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2160,7 +2160,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let c = MutinyWalletConfigBuilder::new(xpriv)
@@ -2182,7 +2182,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let seed = generate_seed(12).expect("Failed to gen seed");
         let network = Network::Regtest;
         let xpriv = Xpriv::new_master(network, &seed.to_seed("")).unwrap();
@@ -2226,7 +2226,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let seed = generate_seed(12).expect("Failed to gen seed");
         let network = Network::Regtest;
         let xpriv = Xpriv::new_master(network, &seed.to_seed("")).unwrap();

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -957,8 +957,8 @@ mod tests {
         );
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let logger = Arc::new(MutinyLogger::default());
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None, logger.clone());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),
             esplora.clone(),

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -957,7 +957,7 @@ mod tests {
         );
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None, None);
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -239,7 +239,7 @@ pub trait MutinyStorage: Clone + Sized + Send + Sync + 'static {
         // save to VSS by spawn an async task
         log_debug!(self.logger(), "writing to VSS");
         if let Some(cb) = self.ln_event_callback().as_ref() {
-            let event = CommonLnEvent::BeforeSyncToVss {
+            let event = CommonLnEvent::SyncToVssStarting {
                 key: key.clone(),
                 version,
                 timestamp: now().as_secs(),

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -236,6 +236,10 @@ pub trait MutinyStorage: Clone + Sized + Send + Sync + 'static {
         let json: Value = encrypt_value(key_clone.clone(), local_data, self.cipher())?;
         self.write_raw(vec![(key_clone, json)])?;
 
+        if self.vss_client().is_none() || version.is_none() {
+            return Ok(());
+        }
+
         // save to VSS by spawn an async task
         log_debug!(self.logger(), "writing to VSS");
         if let Some(cb) = self.ln_event_callback().as_ref() {

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.12.2"
+version = "1.13.0"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/indexed_db.rs
+++ b/mutiny-wasm/src/indexed_db.rs
@@ -346,7 +346,7 @@ impl IndexedDbStorage {
 
         let start = instant::Instant::now();
         // use a memory storage to handle encryption and decryption
-        let map = MemoryStorage::new(password, cipher, None, None);
+        let map = MemoryStorage::new(password, cipher, None, None, logger.clone().into());
 
         let all_json = store.get_all(None, None, None, None).await.map_err(|e| {
             MutinyError::read_err(anyhow!("Failed to get all from store: {e}").into())
@@ -761,6 +761,10 @@ impl MutinyStorage for IndexedDbStorage {
 
     fn ln_event_callback(&self) -> Option<CommonLnEventCallback> {
         self.ln_event_callback.clone()
+    }
+
+    fn logger(&self) -> Arc<MutinyLogger> {
+        self.logger.clone()
     }
 
     fn activity_index(&self) -> Arc<RwLock<BTreeSet<IndexItem>>> {

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -307,8 +307,15 @@ impl MutinyWallet {
             }
         };
 
-        let storage =
-            IndexedDbStorage::new(database, password, cipher, vss_client, logger.clone()).await?;
+        let storage = IndexedDbStorage::new(
+            database,
+            password,
+            cipher,
+            vss_client,
+            ln_event_callback.clone(),
+            logger.clone(),
+        )
+        .await?;
 
         let mut config_builder = MutinyWalletConfigBuilder::new(xprivkey).with_network(network);
         if let Some(w) = websocket_proxy_addr {
@@ -1203,7 +1210,7 @@ impl MutinyWallet {
             .map(|p| encryption_key_from_pass(p))
             .transpose()?;
         // todo init vss
-        let storage = IndexedDbStorage::new(database, password, cipher, None, logger).await?;
+        let storage = IndexedDbStorage::new(database, password, cipher, None, None, logger).await?;
         if storage.get_mnemonic().is_err() {
             // if we get an error, then we have the wrong password
             return Err(MutinyJsError::IncorrectPassword);
@@ -1246,7 +1253,7 @@ impl MutinyWallet {
             .map(|p| encryption_key_from_pass(p))
             .transpose()?;
         let storage =
-            IndexedDbStorage::new(database, password, cipher, None, logger.clone()).await?;
+            IndexedDbStorage::new(database, password, cipher, None, None, logger.clone()).await?;
         mutiny_core::MutinyWallet::<IndexedDbStorage>::restore_mnemonic(
             storage,
             Mnemonic::from_str(&m).map_err(|_| MutinyJsError::InvalidMnemonic)?,


### PR DESCRIPTION
Add 2 events `SyncToVssStarting` and `SyncToVssCompleted` which can be used by the front-end to prompt the user to wait for the synchronization to complete.

```rust
    // Before sync to VSS
    SyncToVssStarting {
        key: String,
        version: Option<u32>,
        timestamp: u64,
    },
    // Sync to VSS completed
    SyncToVssCompleted {
        key: String,
        version: Option<u32>,
        timestamp: u64,
        duration_ms: u128,
    },
```

Note that “device_lock” can be ignored as this is a device heartbeat.

```bash
2025-02-25 08:27:48.914 b133 DEBUG [mutiny_core::storage:245] writing to VSS "device_lock"
...
2025-02-25 08:27:49.537 b133 DEBUG [mutiny_core::storage:261] done writing to VSS "device_lock", took 621ms
```