### PR TITLE
fix: `set_device_lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.14.1"
+version = "1.14.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -180,6 +180,8 @@ pub enum MutinyError {
     JwtAuthFailure,
     #[error("Failed to parse VSS value from getObject response.")]
     FailedParsingVssValue,
+    #[error("Device lock changed when connecting.")]
+    DeviceLockChangedWhenConnecting,
     #[error(transparent)]
     Other(anyhow::Error),
 }

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -86,6 +86,12 @@ pub enum CommonLnEvent {
         timestamp: u64,
         duration_ms: u128,
     },
+    // Device lock changed when connecting
+    DeviceLockChangedWhenConnecting {
+        remote_device: String,
+        local_device: String,
+        timestamp: u64,
+    },
 }
 
 #[derive(Clone)]

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -557,7 +557,7 @@ pub trait MutinyStorage: Clone + Sized + Send + Sync + 'static {
     ) -> Result<(), MutinyError> {
         let device = self.get_device_id()?;
         let device_description = self.get_device_description();
-        if let Some(lock) = self.get_device_lock()? {
+        if let Some(lock) = self.fetch_device_lock().await? {
             if lock.is_locked(&device) {
                 log_debug!(logger, "current device is {}", device);
                 log_debug!(logger, "locked device is {}", lock.device);

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.14.1"
+version = "1.14.2"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -190,6 +190,8 @@ pub enum MutinyJsError {
     JwtAuthFailure,
     #[error("Failed to parse VSS value from getObject response.")]
     FailedParsingVssValue,
+    #[error("Device lock has changed when connecting.")]
+    DeviceLockChangedWhenConnecting,
     #[error("Cannot have more than one node.")]
     TooManyNodes,
     /// Unknown error.
@@ -260,6 +262,9 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::InvalidHex => MutinyJsError::InvalidHex,
             MutinyError::JwtAuthFailure => MutinyJsError::JwtAuthFailure,
             MutinyError::FailedParsingVssValue => MutinyJsError::FailedParsingVssValue,
+            MutinyError::DeviceLockChangedWhenConnecting => {
+                MutinyJsError::DeviceLockChangedWhenConnecting
+            }
         }
     }
 }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -551,6 +551,15 @@ impl MutinyWallet {
         Ok(self.inner.stop().await?)
     }
 
+    /// Returns if the current device is locked.
+    #[wasm_bindgen]
+    pub async fn check_device_lock_ready(&mut self) -> Result<bool, MutinyJsError> {
+        self.inner
+            .check_device_lock_ready()
+            .await
+            .map_err(Into::into)
+    }
+
     /// Returns the mnemonic seed phrase for the wallet.
     #[wasm_bindgen]
     pub fn show_seed(&self) -> String {


### PR DESCRIPTION
Fix:

* [`mutiny-core/src/storage.rs`](diffhunk://#diff-a83de1c69f8e5c886138a8004d612739c40a66b15d41ad8581e106121056ce7eL560-R560): Changed the `get_device_lock` method to `fetch_device_lock`.
  * If the app resumes from a previously suspended state to the foreground on the current device, `get_device_lock` may fail to acquire the lock from the VSS side, causing the device-switch detection logic for LND snapshot updates to be skipped. 
* Adjusted the timing of update_lnd_snapshot invocation to occur only after set_device_lock has been successfully called.
  * Only update the LND snapshot after confirming that `set_device_lock` has succeeded. Otherwise, devices running stale states could successfully update the LND snapshot, causing inconsistencies.
  
Improve：
* emit `DeviceLockChangedWhenConnecting`. Consider restarting the front-end when it gets the event.
* add wasm method `check_device_lock_ready`. Consider restarting the front-end when it gets the event if get `false`.

Refactoring:

* [`mutiny-core/src/lib.rs`](diffhunk://#diff-22c3389d5ae3fdb45a866971d076fe472e61eff683038900f44d4d2d12948c8fR824-R867): Added the `update_lnd_snapshot` async function to the `MutinyWalletBuilder` to handle fetching and saving LND channel snapshots. This refactoring simplifies the method by extracting the LND snapshot logic into a separate function. [[1]](diffhunk://#diff-22c3389d5ae3fdb45a866971d076fe472e61eff683038900f44d4d2d12948c8fR824-R867) [[2]](diffhunk://#diff-22c3389d5ae3fdb45a866971d076fe472e61eff683038900f44d4d2d12948c8fL930-R985)

Version update:

* [`mutiny-wasm/Cargo.toml`](diffhunk://#diff-6b5dca04f2536eeedc58017a518573ae8ad5713a72bd50f626dffc2bfc7e01f6L5-R5): Updated the package version from `1.14.1` to `1.14.2`.