### PR TITLE
fix: handle vss key not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.14.2"
+version = "1.14.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -180,6 +180,8 @@ pub enum MutinyError {
     JwtAuthFailure,
     #[error("Failed to parse VSS value from getObject response.")]
     FailedParsingVssValue,
+    #[error("VSS key not found.")]
+    VssKeyNotFound,
     #[error("Device lock changed when connecting.")]
     DeviceLockChangedWhenConnecting,
     #[error(transparent)]

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -929,6 +929,9 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
                             }
                         }
                     }
+                    Err(MutinyError::VssKeyNotFound) => {
+                        log_info!(logger, "VSS key not found, retrying... {retries}");
+                    }
                     Err(MutinyError::FailedParsingVssValue) => {
                         log_info!(logger, "Failed to parse VSS value, retrying... {retries}");
                     }

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -561,7 +561,7 @@ pub trait MutinyStorage: Clone + Sized + Send + Sync + 'static {
         let lock = match self.fetch_device_lock().await {
             Ok(lock) => lock,
             Err(MutinyError::VssKeyNotFound) => {
-                log_debug!(logger, "Device lock not yet created, proceeding...");
+                log_debug!(logger, "Vss device lock not yet created, proceeding...");
                 None
             }
             Err(e) => {

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -557,7 +557,19 @@ pub trait MutinyStorage: Clone + Sized + Send + Sync + 'static {
     ) -> Result<(), MutinyError> {
         let device = self.get_device_id()?;
         let device_description = self.get_device_description();
-        if let Some(lock) = self.fetch_device_lock().await? {
+
+        let lock = match self.fetch_device_lock().await {
+            Ok(lock) => lock,
+            Err(MutinyError::VssKeyNotFound) => {
+                log_debug!(logger, "Device lock not yet created, proceeding...");
+                None
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        };
+
+        if let Some(lock) = lock {
             if lock.is_locked(&device) {
                 log_debug!(logger, "current device is {}", device);
                 log_debug!(logger, "locked device is {}", lock.device);

--- a/mutiny-core/src/vss.rs
+++ b/mutiny-core/src/vss.rs
@@ -180,7 +180,7 @@ impl MutinyVssClient {
         if response_text == "null" {
             log_debug!(
                 self.logger,
-                "Key not found, response is 'null' for key: {}",
+                "Vss key not found, response is 'null' for key: {}",
                 key
             );
             return Err(MutinyError::VssKeyNotFound);

--- a/mutiny-core/src/vss.rs
+++ b/mutiny-core/src/vss.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
 use hex_conservative::DisplayHex;
 use lightning::util::logger::*;
-use lightning::{log_error, log_info, log_warn};
+use lightning::{log_debug, log_error, log_info, log_warn};
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -170,12 +170,24 @@ impl MutinyVssClient {
 
         let body = json!({ "store_id": self.store_id, "key": key });
 
-        let result: EncryptedVssKeyValueItem = self
-            .make_request(Method::POST, url, Some(body))
-            .await?
-            .json()
-            .await
-            .map_err(|e| {
+        let response = self.make_request(Method::POST, url, Some(body)).await?;
+
+        let response_text = response.text().await.map_err(|e| {
+            log_error!(self.logger, "Error reading response body: {e}");
+            MutinyError::FailedParsingVssValue
+        })?;
+
+        if response_text == "null" {
+            log_debug!(
+                self.logger,
+                "Key not found, response is 'null' for key: {}",
+                key
+            );
+            return Err(MutinyError::VssKeyNotFound);
+        }
+
+        let result: EncryptedVssKeyValueItem =
+            serde_json::from_str(&response_text).map_err(|e| {
                 log_error!(self.logger, "Error parsing get objects response: {e}");
                 MutinyError::FailedParsingVssValue
             })?;

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.14.2"
+version = "1.14.3"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -190,6 +190,8 @@ pub enum MutinyJsError {
     JwtAuthFailure,
     #[error("Failed to parse VSS value from getObject response.")]
     FailedParsingVssValue,
+    #[error("VSS key not found.")]
+    VssKeyNotFound,
     #[error("Device lock has changed when connecting.")]
     DeviceLockChangedWhenConnecting,
     #[error("Cannot have more than one node.")]
@@ -262,6 +264,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::InvalidHex => MutinyJsError::InvalidHex,
             MutinyError::JwtAuthFailure => MutinyJsError::JwtAuthFailure,
             MutinyError::FailedParsingVssValue => MutinyJsError::FailedParsingVssValue,
+            MutinyError::VssKeyNotFound => MutinyJsError::VssKeyNotFound,
             MutinyError::DeviceLockChangedWhenConnecting => {
                 MutinyJsError::DeviceLockChangedWhenConnecting
             }


### PR DESCRIPTION
This pull request introduces a new error type `VssKeyNotFound` to handle cases where a VSS key is not found, along with the necessary logging and error handling updates across various files in the `mutiny-core` and `mutiny-wasm` modules.