### PR TITLE
check peer connection when update lnd snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.14.4"
+version = "1.14.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -28,7 +28,7 @@ mod networking;
 mod node;
 pub mod nodemanager;
 mod onchain;
-mod peermanager;
+pub mod peermanager;
 pub mod scorer;
 pub mod storage;
 mod subscription;

--- a/mutiny-core/src/peermanager.rs
+++ b/mutiny-core/src/peermanager.rs
@@ -635,10 +635,7 @@ impl ConnectedPeerManager {
         let mut peers = self.peers.lock().unwrap();
         let inserted = peers.insert(their_node_id, info).is_none();
         let logger = {
-            let guard = self.logger.lock().expect(
-                "
-                Failed to lock logger",
-            );
+            let guard = self.logger.lock().expect("Failed to lock logger");
             guard.clone()
         };
         if inserted {
@@ -653,10 +650,7 @@ impl ConnectedPeerManager {
         let removed = peers.remove(their_node_id).is_some();
 
         let logger = {
-            let guard = self.logger.lock().expect(
-                "
-                Failed to lock logger",
-            );
+            let guard = self.logger.lock().expect("Failed to lock logger");
             guard.clone()
         };
         if removed {

--- a/mutiny-core/src/vss.rs
+++ b/mutiny-core/src/vss.rs
@@ -250,10 +250,10 @@ impl VssManager {
 
     pub fn get_pending_writes(&self) -> Vec<(String, VssPendingWrite)> {
         self.check_timeout();
-        let writes = self.pending_writes.lock().expect(
-            "
-            Failed to lock pending writes",
-        );
+        let writes = self
+            .pending_writes
+            .lock()
+            .expect("Failed to lock pending writes");
         writes.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
     }
 
@@ -271,33 +271,30 @@ impl VssManager {
     }
 
     pub fn on_complete_write(&self, key: String) {
-        let mut pending_writes = self.pending_writes.lock().expect(
-            "
-            Failed to lock pending writes",
-        );
+        let mut pending_writes = self
+            .pending_writes
+            .lock()
+            .expect("Failed to lock pending writes");
         pending_writes.remove(&key);
     }
 
     pub fn has_in_progress(&self) -> bool {
         self.check_timeout();
-        let writes = self.pending_writes.lock().expect(
-            "
-            Failed to lock pending writes",
-        );
+        let writes = self
+            .pending_writes
+            .lock()
+            .expect("Failed to lock pending writes");
         !writes.is_empty()
     }
 
     fn check_timeout(&self) {
         let current_time = utils::now().as_secs();
-        let mut writes = self.pending_writes.lock().expect(
-            "
-            Failed to lock pending writes",
-        );
+        let mut writes = self
+            .pending_writes
+            .lock()
+            .expect("Failed to lock pending writes");
         let logger = {
-            let guard = self.logger.lock().expect(
-                "
-                Failed to lock logger",
-            );
+            let guard = self.logger.lock().expect("Failed to lock logger");
             guard.clone()
         };
         writes.retain(|key, write| {

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.14.4"
+version = "1.14.5"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -32,6 +32,7 @@ use mutiny_core::authmanager::AuthManager;
 use mutiny_core::encrypt::decrypt_with_password;
 use mutiny_core::error::MutinyError;
 use mutiny_core::messagehandler::{CommonLnEvent, CommonLnEventCallback};
+use mutiny_core::peermanager::CONNECTED_PEER_MANAGER;
 use mutiny_core::storage::{DeviceLock, MutinyStorage, DEVICE_LOCK_KEY};
 use mutiny_core::utils::sleep;
 use mutiny_core::vss::{MutinyVssClient, VSS_MANAGER};
@@ -225,6 +226,7 @@ impl MutinyWallet {
         log_info!(logger, "Node version {version}");
 
         VSS_MANAGER.set_logger(logger.clone());
+        CONNECTED_PEER_MANAGER.set_logger(logger.clone());
 
         let cipher = password
             .as_ref()


### PR DESCRIPTION
This PR improves the logic for updating the LND channels snapshot by adding a check to ensure that peers are currently connected. The snapshot will now only be updated if:

- No VSS writes are pending, or only the device lock is pending, and
- There are connected peers

This avoids unnecessary snapshot updates when the node is not connected to the network.

---

As a next step, if the LND snapshot includes a `local_pubkey` field, we can cross-check it with the currently connected peers to further strengthen the validation logic. 


---

- [x] local tested