### PR TITLE
validate peer connections from lnd channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mutiny-core/src/lsp/lndchannel.rs
+++ b/mutiny-core/src/lsp/lndchannel.rs
@@ -23,6 +23,7 @@ pub struct ChannelConstraints {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LndChannel {
     pub active: bool,
+    pub local_pubkey: String,
     pub remote_pubkey: String,
     pub channel_point: String,
     pub chan_id: String,

--- a/mutiny-core/src/peermanager.rs
+++ b/mutiny-core/src/peermanager.rs
@@ -663,7 +663,7 @@ impl ConnectedPeerManager {
     }
 
     pub fn validate_peer_connections(&self, channels: &[LndChannel]) -> bool {
-        let (peers_from_lnd, valid) =
+        let (peers_of_active_channels, valid) =
             channels
                 .iter()
                 .fold(
@@ -690,10 +690,10 @@ impl ConnectedPeerManager {
             peers.keys().cloned().collect::<HashSet<_>>()
         };
 
-        let is_match = peers_from_lnd.is_subset(&peers_in_manager);
+        let is_match = peers_of_active_channels.is_subset(&peers_in_manager);
         if !is_match {
             if let Some(l) = &*self.logger.lock().unwrap() {
-                peers_from_lnd
+                peers_of_active_channels
                     .difference(&peers_in_manager)
                     .for_each(|pk| log_warn!(l, "Missing peer: {}", pk));
             }

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.14.5"
+version = "1.14.6"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"


### PR DESCRIPTION
* Added a new field `local_pubkey` to the `LndChannel` struct to store the lnd node public key.
* Modified the condition for updating snapshots to use the new `validate_peer_connections` method instead of `is_any_connected`.

- [x] local tested

