### PR TITLE
bump LDK to v0.0.125

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,8 +1236,8 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "lightning"
-version = "0.0.124"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=fix-channel-manager-wasm32#bdbfd070a10f46653c396788ffc49e6cb6ebb00f"
+version = "0.0.125"
+source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -1249,8 +1249,8 @@ dependencies = [
 
 [[package]]
 name = "lightning-background-processor"
-version = "0.0.124"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=fix-channel-manager-wasm32#bdbfd070a10f46653c396788ffc49e6cb6ebb00f"
+version = "0.0.125"
+source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "lightning-common"
 version = "0.1.0"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=fix-channel-manager-wasm32#bdbfd070a10f46653c396788ffc49e6cb6ebb00f"
+source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
 dependencies = [
  "web-time",
 ]
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.32.0"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=fix-channel-manager-wasm32#bdbfd070a10f46653c396788ffc49e6cb6ebb00f"
+source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-liquidity"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49afbc99fa165be9e106516e475d518620015ce5f264ae6e349948b29da1f868"
+checksum = "175cff5d30b8d3f94ae9772b59f9ca576b1927a6ab60dd773e8c4e0593cd4e95"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-net-tokio"
-version = "0.0.124"
+version = "0.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83c367f1f524754b0fd38ed590bcc7dbe4d1d599607c664b243239bc917da05"
+checksum = "af2847a19f892f32b9ab5075af25c70370b4cc5842b4f5b53c57092e52a49498"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1306,8 +1306,8 @@ dependencies = [
 
 [[package]]
 name = "lightning-rapid-gossip-sync"
-version = "0.0.124"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=fix-channel-manager-wasm32#bdbfd070a10f46653c396788ffc49e6cb6ebb00f"
+version = "0.0.125"
+source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1316,8 +1316,8 @@ dependencies = [
 
 [[package]]
 name = "lightning-transaction-sync"
-version = "0.0.124"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=fix-channel-manager-wasm32#bdbfd070a10f46653c396788ffc49e6cb6ebb00f"
+version = "0.0.125"
+source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.1.0"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=fix-channel-manager-wasm32#bdbfd070a10f46653c396788ffc49e6cb6ebb00f"
+source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-wasm"
-version = "1.14.6"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,7 +1237,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "lightning"
 version = "0.0.125"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
+source = "git+https://github.com/utxostack/rust-lightning.git?tag=wasm-v0.0.125#90228d9f849c782ca1f42dbdf3a48538d55536c2"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -1250,7 +1250,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.125"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
+source = "git+https://github.com/utxostack/rust-lightning.git?tag=wasm-v0.0.125#90228d9f849c782ca1f42dbdf3a48538d55536c2"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "lightning-common"
 version = "0.1.0"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
+source = "git+https://github.com/utxostack/rust-lightning.git?tag=wasm-v0.0.125#90228d9f849c782ca1f42dbdf3a48538d55536c2"
 dependencies = [
  "web-time",
 ]
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.32.0"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
+source = "git+https://github.com/utxostack/rust-lightning.git?tag=wasm-v0.0.125#90228d9f849c782ca1f42dbdf3a48538d55536c2"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.125"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
+source = "git+https://github.com/utxostack/rust-lightning.git?tag=wasm-v0.0.125#90228d9f849c782ca1f42dbdf3a48538d55536c2"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.125"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
+source = "git+https://github.com/utxostack/rust-lightning.git?tag=wasm-v0.0.125#90228d9f849c782ca1f42dbdf3a48538d55536c2"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.1.0"
-source = "git+https://github.com/utxostack/rust-lightning.git?branch=wasm-adapt#826daa7924f4ecb2e861d26f3484c907b5751076"
+source = "git+https://github.com/utxostack/rust-lightning.git?tag=wasm-v0.0.125#90228d9f849c782ca1f42dbdf3a48538d55536c2"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ opt-level = "z"
 opt-level = "z"
 
 [patch.crates-io]
-lightning-background-processor = { git = "https://github.com/utxostack/rust-lightning.git", branch = "fix-channel-manager-wasm32" }
-lightning = { git = "https://github.com/utxostack/rust-lightning.git", branch = "fix-channel-manager-wasm32" }
-lightning-types = { git = "https://github.com/utxostack/rust-lightning.git", branch = "fix-channel-manager-wasm32" }
-lightning-invoice = { git = "https://github.com/utxostack/rust-lightning.git", branch = "fix-channel-manager-wasm32" }
-lightning-rapid-gossip-sync = { git = "https://github.com/utxostack/rust-lightning.git", branch = "fix-channel-manager-wasm32" }
-lightning-transaction-sync = { git = "https://github.com/utxostack/rust-lightning.git", branch = "fix-channel-manager-wasm32" }
+lightning-background-processor = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
+lightning = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
+lightning-types = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
+lightning-invoice = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
+lightning-rapid-gossip-sync = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
+lightning-transaction-sync = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ opt-level = "z"
 opt-level = "z"
 
 [patch.crates-io]
-lightning-background-processor = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
-lightning = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
-lightning-types = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
-lightning-invoice = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
-lightning-rapid-gossip-sync = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
-lightning-transaction-sync = { git = "https://github.com/utxostack/rust-lightning.git", branch = "wasm-adapt" }
+lightning-background-processor = { git = "https://github.com/utxostack/rust-lightning.git", tag = "wasm-v0.0.125" }
+lightning = { git = "https://github.com/utxostack/rust-lightning.git", tag = "wasm-v0.0.125" }
+lightning-types = { git = "https://github.com/utxostack/rust-lightning.git", tag = "wasm-v0.0.125" }
+lightning-invoice = { git = "https://github.com/utxostack/rust-lightning.git", tag = "wasm-v0.0.125" }
+lightning-rapid-gossip-sync = { git = "https://github.com/utxostack/rust-lightning.git", tag = "wasm-v0.0.125" }
+lightning-transaction-sync = { git = "https://github.com/utxostack/rust-lightning.git", tag = "wasm-v0.0.125" }

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -38,18 +38,18 @@ uuid = { version = "1.1.2", features = ["v4"] }
 esplora-client = { version = "0.9", default-features = false, features = [
   "async",
 ] }
-lightning = { version = "0.0.124", default-features = false, features = [
+lightning = { version = "0.0.125", default-features = false, features = [
   "max_level_trace",
   "grind_signatures",
   "std",
 ] }
 lightning-invoice = { version = "0.32.0", features = ["serde"] }
-lightning-rapid-gossip-sync = { version = "0.0.124" }
-lightning-background-processor = { version = "0.0.124", features = ["futures"] }
-lightning-transaction-sync = { version = "0.0.124", default-features = false, features = [
+lightning-rapid-gossip-sync = { version = "0.0.125" }
+lightning-background-processor = { version = "0.0.125", features = ["futures"] }
+lightning-transaction-sync = { version = "0.0.125", default-features = false, features = [
   "esplora-async-https",
 ] }
-lightning-liquidity = "0.1.0-alpha.5"
+lightning-liquidity = "=0.1.0-alpha.6"
 chrono = "0.4.22"
 futures-util = { version = "0.3", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = [
@@ -98,7 +98,7 @@ js-sys = "0.3.65"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
-lightning-net-tokio = "0.0.124"
+lightning-net-tokio = "0.0.125"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["per-package-target"]
 
 [package]
 name = "mutiny-wasm"
-version = "1.14.6"
+version = "1.15.0"
 edition = "2021"
 authors = ["utxostack"]
 forced-target = "wasm32-unknown-unknown"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -32,7 +32,7 @@ bitcoin = { version = "0.32.2", default-features = false, features = [
   "secp-recovery",
   "rand",
 ] }
-lightning = { version = "0.0.124", default-features = false, features = [
+lightning = { version = "0.0.125", default-features = false, features = [
   "std",
 ] }
 lightning-invoice = { version = "0.32.0" }


### PR DESCRIPTION
- bump LDK to [wasm-v0.0.125](https://github.com/utxostack/rust-lightning/releases/tag/wasm-v0.0.125), based on [v0.0.125](https://github.com/lightningdevkit/rust-lightning/releases/tag/v0.0.125), which fixes a potential force close vulnerability in specific channel states
- upgrade LDK without parallel branch maintenance
  • LDK contains only patch-level changes from v0.0.124 (~50 LoC diff)
  • No breaking API changes detected
  • Low-risk upgrade

---

wasm-v0.0.125 Description: 

- makes a very small amount of wasm adaptations based on LDK, without any logic changes
- [WASM-ADAPTATIONS](https://github.com/utxostack/rust-lightning/blob/wasm-adapt/WASM-ADAPTATIONS.md)